### PR TITLE
Fix grammar typo in CSS docs

### DIFF
--- a/docs/components/index.html
+++ b/docs/components/index.html
@@ -1898,7 +1898,7 @@ search_sections: true
     have <code>item-stacked-label</code> assigned, and the input's label
     should have <code>input-label</code> assigned.
     This example also uses the <code>placeholder</code> attribute so
-    user's have a hint of what type of text the input is looking for.
+    users have a hint of what type of text the input is looking for.
   </p>
 
 {% highlight html %}


### PR DESCRIPTION
Changed user's to users. The possessive apostrophe isn't correct in this case.