### PR TITLE
Fixing ion-list documentation

### DIFF
--- a/docs/1.0.0-beta.10/api/directive/ionList/index.md
+++ b/docs/1.0.0-beta.10/api/directive/ionList/index.md
@@ -62,9 +62,9 @@ Related: <a href="/docs/api/directive/ionItem/"><code>ionItem</code></a>, <a hre
 
 
 
-  
+
 <h2 id="usage">Usage</h2>
-  
+
 Basic Usage:
 
 ```html
@@ -81,7 +81,7 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
 <ion-list ng-controller="MyCtrl"
           show-delete="shouldShowDelete"
           show-reorder="shouldShowReorder"
-          can-swipe="listCanSwipe">
+          can-swipe="true">
   <ion-item ng-repeat="item in items"
             class="item-thumbnail-left">
 
@@ -106,8 +106,8 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
   </ion-item>
 </ion-list>
 ```
-  
-  
+
+
 <h2 id="api" style="clear:both;">API</h2>
 
 <table class="table" style="margin:0;">
@@ -119,85 +119,85 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
     </tr>
   </thead>
   <tbody>
-    
+
     <tr>
       <td>
         delegate-handle
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The handle used to identify this list with
 <a href="/docs/api/service/$ionicListDelegate/"><code>$ionicListDelegate</code></a>.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-delete
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the delete buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-reorder
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the reorder buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         can-swipe
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the items in the list are allowed to be swiped to reveal
 option buttons. Default: true.</p>
 
-        
+
       </td>
     </tr>
-    
+
   </tbody>
 </table>
 
-  
 
-  
+
+
 
 
 

--- a/docs/1.0.0-beta.11/api/directive/ionList/index.md
+++ b/docs/1.0.0-beta.11/api/directive/ionList/index.md
@@ -62,9 +62,9 @@ Related: <a href="/docs/api/directive/ionItem/"><code>ionItem</code></a>, <a hre
 
 
 
-  
+
 <h2 id="usage">Usage</h2>
-  
+
 Basic Usage:
 
 ```html
@@ -81,7 +81,7 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
 <ion-list ng-controller="MyCtrl"
           show-delete="shouldShowDelete"
           show-reorder="shouldShowReorder"
-          can-swipe="listCanSwipe">
+          can-swipe="true">
   <ion-item ng-repeat="item in items"
             class="item-thumbnail-left">
 
@@ -106,8 +106,8 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
   </ion-item>
 </ion-list>
 ```
-  
-  
+
+
 <h2 id="api" style="clear:both;">API</h2>
 
 <table class="table" style="margin:0;">
@@ -119,102 +119,102 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
     </tr>
   </thead>
   <tbody>
-    
+
     <tr>
       <td>
         delegate-handle
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The handle used to identify this list with
 <a href="/docs/api/service/$ionicListDelegate/"><code>$ionicListDelegate</code></a>.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         type
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The type of list to use (for example, list-inset for an inset list)</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-delete
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the delete buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-reorder
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the reorder buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         can-swipe
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the items in the list are allowed to be swiped to reveal
 option buttons. Default: true.</p>
 
-        
+
       </td>
     </tr>
-    
+
   </tbody>
 </table>
 
-  
 
-  
+
+
 
 
 

--- a/docs/1.0.0-beta.12/api/directive/ionList/index.md
+++ b/docs/1.0.0-beta.12/api/directive/ionList/index.md
@@ -62,9 +62,9 @@ Related: <a href="/docs/api/directive/ionItem/"><code>ionItem</code></a>, <a hre
 
 
 
-  
+
 <h2 id="usage">Usage</h2>
-  
+
 Basic Usage:
 
 ```html
@@ -81,7 +81,7 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
 <ion-list ng-controller="MyCtrl"
           show-delete="shouldShowDelete"
           show-reorder="shouldShowReorder"
-          can-swipe="listCanSwipe">
+          can-swipe="true">
   <ion-item ng-repeat="item in items"
             class="item-thumbnail-left">
 
@@ -106,8 +106,8 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
   </ion-item>
 </ion-list>
 ```
-  
-  
+
+
 <h2 id="api" style="clear:both;">API</h2>
 
 <table class="table" style="margin:0;">
@@ -119,102 +119,102 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
     </tr>
   </thead>
   <tbody>
-    
+
     <tr>
       <td>
         delegate-handle
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The handle used to identify this list with
 <a href="/docs/api/service/$ionicListDelegate/"><code>$ionicListDelegate</code></a>.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         type
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The type of list to use (for example, list-inset for an inset list)</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-delete
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the delete buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-reorder
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the reorder buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         can-swipe
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the items in the list are allowed to be swiped to reveal
 option buttons. Default: true.</p>
 
-        
+
       </td>
     </tr>
-    
+
   </tbody>
 </table>
 
-  
 
-  
+
+
 
 
 

--- a/docs/1.0.0-beta.13/api/directive/ionList/index.md
+++ b/docs/1.0.0-beta.13/api/directive/ionList/index.md
@@ -62,9 +62,9 @@ Related: <a href="/docs/api/directive/ionItem/"><code>ionItem</code></a>, <a hre
 
 
 
-  
+
 <h2 id="usage">Usage</h2>
-  
+
 Basic Usage:
 
 ```html
@@ -81,7 +81,7 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
 <ion-list ng-controller="MyCtrl"
           show-delete="shouldShowDelete"
           show-reorder="shouldShowReorder"
-          can-swipe="listCanSwipe">
+          can-swipe="true">
   <ion-item ng-repeat="item in items"
             class="item-thumbnail-left">
 
@@ -106,8 +106,8 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
   </ion-item>
 </ion-list>
 ```
-  
-  
+
+
 <h2 id="api" style="clear:both;">API</h2>
 
 <table class="table" style="margin:0;">
@@ -119,102 +119,102 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
     </tr>
   </thead>
   <tbody>
-    
+
     <tr>
       <td>
         delegate-handle
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The handle used to identify this list with
 <a href="/docs/api/service/$ionicListDelegate/"><code>$ionicListDelegate</code></a>.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         type
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The type of list to use (list-inset or card)</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-delete
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the delete buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-reorder
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the reorder buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         can-swipe
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the items in the list are allowed to be swiped to reveal
 option buttons. Default: true.</p>
 
-        
+
       </td>
     </tr>
-    
+
   </tbody>
 </table>
 
-  
 
-  
+
+
 
 
 

--- a/docs/1.0.0-beta.14/api/directive/ionList/index.md
+++ b/docs/1.0.0-beta.14/api/directive/ionList/index.md
@@ -62,9 +62,9 @@ Related: <a href="/docs/api/directive/ionItem/"><code>ionItem</code></a>, <a hre
 
 
 
-  
+
 <h2 id="usage">Usage</h2>
-  
+
 Basic Usage:
 
 ```html
@@ -81,7 +81,7 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
 <ion-list ng-controller="MyCtrl"
           show-delete="shouldShowDelete"
           show-reorder="shouldShowReorder"
-          can-swipe="listCanSwipe">
+          can-swipe="true">
   <ion-item ng-repeat="item in items"
             class="item-thumbnail-left">
 
@@ -106,8 +106,8 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
   </ion-item>
 </ion-list>
 ```
-  
-  
+
+
 <h2 id="api" style="clear:both;">API</h2>
 
 <table class="table" style="margin:0;">
@@ -119,102 +119,102 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
     </tr>
   </thead>
   <tbody>
-    
+
     <tr>
       <td>
         delegate-handle
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The handle used to identify this list with
 <a href="/docs/api/service/$ionicListDelegate/"><code>$ionicListDelegate</code></a>.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         type
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The type of list to use (list-inset or card)</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-delete
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the delete buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-reorder
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the reorder buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         can-swipe
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the items in the list are allowed to be swiped to reveal
 option buttons. Default: true.</p>
 
-        
+
       </td>
     </tr>
-    
+
   </tbody>
 </table>
 
-  
 
-  
+
+
 
 
 

--- a/docs/1.0.0-beta.5/api/directive/ionList/index.md
+++ b/docs/1.0.0-beta.5/api/directive/ionList/index.md
@@ -58,9 +58,9 @@ Related: <a href="/docs/api/directive/ionItem/"><code>ionItem</code></a>, <a hre
 
 
 
-  
+
 <h2 id="usage">Usage</h2>
-  
+
 Basic Usage:
 
 ```html
@@ -77,7 +77,7 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
 <ion-list ng-controller="MyCtrl"
           show-delete="shouldShowDelete"
           show-reorder="shouldShowReorder"
-          can-swipe="listCanSwipe">
+          can-swipe="true">
   <ion-item ng-repeat="item in items"
             class="item-thumbnail-left">
 
@@ -102,8 +102,8 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
   </ion-item>
 </ion-list>
 ```
-  
-  
+
+
 <h2 id="api" style="clear:both;">API</h2>
 
 <table class="table" style="margin:0;">
@@ -115,85 +115,85 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
     </tr>
   </thead>
   <tbody>
-    
+
     <tr>
       <td>
         delegate-handle
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The handle used to identify this list with
 <a href="/docs/api/service/$ionicListDelegate/"><code>$ionicListDelegate</code></a>.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-delete
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the delete buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-reorder
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the reorder buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         can-swipe
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the items in the list are allowed to be swiped to reveal
 option buttons. Default: true.</p>
 
-        
+
       </td>
     </tr>
-    
+
   </tbody>
 </table>
 
-  
 
-  
+
+
 
 
 

--- a/docs/1.0.0-beta.6/api/directive/ionList/index.md
+++ b/docs/1.0.0-beta.6/api/directive/ionList/index.md
@@ -58,9 +58,9 @@ Related: <a href="/docs/api/directive/ionItem/"><code>ionItem</code></a>, <a hre
 
 
 
-  
+
 <h2 id="usage">Usage</h2>
-  
+
 Basic Usage:
 
 ```html
@@ -77,7 +77,7 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
 <ion-list ng-controller="MyCtrl"
           show-delete="shouldShowDelete"
           show-reorder="shouldShowReorder"
-          can-swipe="listCanSwipe">
+          can-swipe="true">
   <ion-item ng-repeat="item in items"
             class="item-thumbnail-left">
 
@@ -102,8 +102,8 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
   </ion-item>
 </ion-list>
 ```
-  
-  
+
+
 <h2 id="api" style="clear:both;">API</h2>
 
 <table class="table" style="margin:0;">
@@ -115,85 +115,85 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
     </tr>
   </thead>
   <tbody>
-    
+
     <tr>
       <td>
         delegate-handle
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The handle used to identify this list with
 <a href="/docs/api/service/$ionicListDelegate/"><code>$ionicListDelegate</code></a>.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-delete
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the delete buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-reorder
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the reorder buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         can-swipe
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the items in the list are allowed to be swiped to reveal
 option buttons. Default: true.</p>
 
-        
+
       </td>
     </tr>
-    
+
   </tbody>
 </table>
 
-  
 
-  
+
+
 
 
 

--- a/docs/1.0.0-beta.7/api/directive/ionList/index.md
+++ b/docs/1.0.0-beta.7/api/directive/ionList/index.md
@@ -62,9 +62,9 @@ Related: <a href="/docs/api/directive/ionItem/"><code>ionItem</code></a>, <a hre
 
 
 
-  
+
 <h2 id="usage">Usage</h2>
-  
+
 Basic Usage:
 
 ```html
@@ -81,7 +81,7 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
 <ion-list ng-controller="MyCtrl"
           show-delete="shouldShowDelete"
           show-reorder="shouldShowReorder"
-          can-swipe="listCanSwipe">
+          can-swipe="true">
   <ion-item ng-repeat="item in items"
             class="item-thumbnail-left">
 
@@ -106,8 +106,8 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
   </ion-item>
 </ion-list>
 ```
-  
-  
+
+
 <h2 id="api" style="clear:both;">API</h2>
 
 <table class="table" style="margin:0;">
@@ -119,85 +119,85 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
     </tr>
   </thead>
   <tbody>
-    
+
     <tr>
       <td>
         delegate-handle
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The handle used to identify this list with
 <a href="/docs/api/service/$ionicListDelegate/"><code>$ionicListDelegate</code></a>.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-delete
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the delete buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-reorder
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the reorder buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         can-swipe
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the items in the list are allowed to be swiped to reveal
 option buttons. Default: true.</p>
 
-        
+
       </td>
     </tr>
-    
+
   </tbody>
 </table>
 
-  
 
-  
+
+
 
 
 

--- a/docs/1.0.0-beta.8/api/directive/ionList/index.md
+++ b/docs/1.0.0-beta.8/api/directive/ionList/index.md
@@ -62,9 +62,9 @@ Related: <a href="/docs/api/directive/ionItem/"><code>ionItem</code></a>, <a hre
 
 
 
-  
+
 <h2 id="usage">Usage</h2>
-  
+
 Basic Usage:
 
 ```html
@@ -81,7 +81,7 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
 <ion-list ng-controller="MyCtrl"
           show-delete="shouldShowDelete"
           show-reorder="shouldShowReorder"
-          can-swipe="listCanSwipe">
+          can-swipe="true">
   <ion-item ng-repeat="item in items"
             class="item-thumbnail-left">
 
@@ -106,8 +106,8 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
   </ion-item>
 </ion-list>
 ```
-  
-  
+
+
 <h2 id="api" style="clear:both;">API</h2>
 
 <table class="table" style="margin:0;">
@@ -119,85 +119,85 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
     </tr>
   </thead>
   <tbody>
-    
+
     <tr>
       <td>
         delegate-handle
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The handle used to identify this list with
 <a href="/docs/api/service/$ionicListDelegate/"><code>$ionicListDelegate</code></a>.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-delete
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the delete buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-reorder
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the reorder buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         can-swipe
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the items in the list are allowed to be swiped to reveal
 option buttons. Default: true.</p>
 
-        
+
       </td>
     </tr>
-    
+
   </tbody>
 </table>
 
-  
 
-  
+
+
 
 
 

--- a/docs/1.0.0-beta.9/api/directive/ionList/index.md
+++ b/docs/1.0.0-beta.9/api/directive/ionList/index.md
@@ -62,9 +62,9 @@ Related: <a href="/docs/api/directive/ionItem/"><code>ionItem</code></a>, <a hre
 
 
 
-  
+
 <h2 id="usage">Usage</h2>
-  
+
 Basic Usage:
 
 ```html
@@ -81,7 +81,7 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
 <ion-list ng-controller="MyCtrl"
           show-delete="shouldShowDelete"
           show-reorder="shouldShowReorder"
-          can-swipe="listCanSwipe">
+          can-swipe="true">
   <ion-item ng-repeat="item in items"
             class="item-thumbnail-left">
 
@@ -106,8 +106,8 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
   </ion-item>
 </ion-list>
 ```
-  
-  
+
+
 <h2 id="api" style="clear:both;">API</h2>
 
 <table class="table" style="margin:0;">
@@ -119,85 +119,85 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
     </tr>
   </thead>
   <tbody>
-    
+
     <tr>
       <td>
         delegate-handle
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The handle used to identify this list with
 <a href="/docs/api/service/$ionicListDelegate/"><code>$ionicListDelegate</code></a>.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-delete
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the delete buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-reorder
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the reorder buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         can-swipe
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the items in the list are allowed to be swiped to reveal
 option buttons. Default: true.</p>
 
-        
+
       </td>
     </tr>
-    
+
   </tbody>
 </table>
 
-  
 
-  
+
+
 
 
 

--- a/docs/api/directive/ionList/index.md
+++ b/docs/api/directive/ionList/index.md
@@ -62,9 +62,9 @@ Related: <a href="/docs/api/directive/ionItem/"><code>ionItem</code></a>, <a hre
 
 
 
-  
+
 <h2 id="usage">Usage</h2>
-  
+
 Basic Usage:
 
 ```html
@@ -81,7 +81,7 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
 <ion-list ng-controller="MyCtrl"
           show-delete="shouldShowDelete"
           show-reorder="shouldShowReorder"
-          can-swipe="listCanSwipe">
+          can-swipe="true">
   <ion-item ng-repeat="item in items"
             class="item-thumbnail-left">
 
@@ -106,8 +106,8 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
   </ion-item>
 </ion-list>
 ```
-  
-  
+
+
 <h2 id="api" style="clear:both;">API</h2>
 
 <table class="table" style="margin:0;">
@@ -119,102 +119,102 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
     </tr>
   </thead>
   <tbody>
-    
+
     <tr>
       <td>
         delegate-handle
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The handle used to identify this list with
 <a href="/docs/api/service/$ionicListDelegate/"><code>$ionicListDelegate</code></a>.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         type
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The type of list to use (list-inset or card)</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-delete
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the delete buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-reorder
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the reorder buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         can-swipe
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the items in the list are allowed to be swiped to reveal
 option buttons. Default: true.</p>
 
-        
+
       </td>
     </tr>
-    
+
   </tbody>
 </table>
 
-  
 
-  
+
+
 
 
 

--- a/docs/nightly/api/directive/ionList/index.md
+++ b/docs/nightly/api/directive/ionList/index.md
@@ -62,9 +62,9 @@ Related: <a href="/docs/nightly/api/directive/ionItem/"><code>ionItem</code></a>
 
 
 
-  
+
 <h2 id="usage">Usage</h2>
-  
+
 Basic Usage:
 
 ```html
@@ -81,7 +81,7 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
 <ion-list ng-controller="MyCtrl"
           show-delete="shouldShowDelete"
           show-reorder="shouldShowReorder"
-          can-swipe="listCanSwipe">
+          can-swipe="true">
   <ion-item ng-repeat="item in items"
             class="item-thumbnail-left">
 
@@ -106,8 +106,8 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
   </ion-item>
 </ion-list>
 ```
-  
-  
+
+
 <h2 id="api" style="clear:both;">API</h2>
 
 <table class="table" style="margin:0;">
@@ -119,102 +119,102 @@ Advanced Usage: Thumbnails, Delete buttons, Reordering, Swiping
     </tr>
   </thead>
   <tbody>
-    
+
     <tr>
       <td>
         delegate-handle
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The handle used to identify this list with
 <a href="/docs/nightly/api/service/$ionicListDelegate/"><code>$ionicListDelegate</code></a>.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         type
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>string</code>
       </td>
       <td>
         <p>The type of list to use (list-inset or card)</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-delete
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the delete buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         show-reorder
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the reorder buttons for the items in the list are
 currently shown or hidden.</p>
 
-        
+
       </td>
     </tr>
-    
+
     <tr>
       <td>
         can-swipe
-        
+
         <div><em>(optional)</em></div>
       </td>
       <td>
-        
+
   <code>boolean</code>
       </td>
       <td>
         <p>Whether the items in the list are allowed to be swiped to reveal
 option buttons. Default: true.</p>
 
-        
+
       </td>
     </tr>
-    
+
   </tbody>
 </table>
 
-  
 
-  
+
+
 
 
 


### PR DESCRIPTION
On list documentation there is no `listCanSwipe` on `$scope`
with a boolean value. So I changed to `true` that is the default
value of `can-swipe` attr and keep the context of doc example