### PR TITLE
feat(docs): add CLI to docs

### DIFF
--- a/_layouts/docs_api.html
+++ b/_layouts/docs_api.html
@@ -71,6 +71,12 @@
 
             <ul class="nav left-menu">
               <li class="menu-title">
+                <a href="/docs/cli/">CLI</a>
+              </li>
+            </ul>
+
+            <ul class="nav left-menu">
+              <li class="menu-title">
                 <a href="http://learn.ionicframework.com/">Learn Ionic</a>
               </li>
             </ul>

--- a/_layouts/docs_cli.html
+++ b/_layouts/docs_cli.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  {% include meta_tags.html %}
+  <title>{{page.title}} - Ionic Framework</title>
+  {% include head_includes.html %}
+</head>
+
+<body class="docs docs-page docs-home">
+
+{% include nav_links.html %}
+
+{% include header.html %}
+
+<div class="container content-container">
+
+  <div class="row">
+
+    <div class="col-md-2 col-sm-3 aside-menu">
+
+      <div class="docked-menu">
+
+        <ul class="nav left-menu">
+          <li class="menu-title">
+            <a href="/docs/overview/">Overview</a>
+          </li>
+        </ul>
+
+        <ul class="nav left-menu">
+          <li class="menu-title">
+            <a href="/docs/components/">CSS</a>
+          </li>
+        </ul>
+
+        <ul class="nav left-menu">
+          <li class="menu-title">
+            <a href="/docs/api/">JavaScript</a>
+          </li>
+        </ul>
+
+        <ul class="nav left-menu active-menu">
+          <li class="menu-title">
+            <a href="/docs/cli/">CLI</a>
+          </li>
+          <li><a href="/docs/cli/install.html">Install</a></li>
+          <li><a href="/docs/cli/start.html">Start</a></li>
+          <li><a href="/docs/cli/test.html">Testing</a></li>
+          <li><a href="/docs/cli/run.html">Run & Emulate</a></li>
+          <li><a href="/docs/cli/icon-splashscreen.html">Icon & Splashscreen</a></li>
+          <!--<li><a href="/docs/cli/package.html">Package</a></li>-->
+          <li><a href="/docs/cli/sass.html">SASS</a></li>
+        </ul>
+
+        <ul class="nav left-menu">
+          <li class="menu-title">
+            <a href="http://learn.ionicframework.com/">Learn Ionic</a>
+          </li>
+        </ul>
+
+        <ul class="nav left-menu">
+          <li class="menu-title">
+            <a href="/docs/guide/">Guide</a>
+          </li>
+        </ul>
+
+        <ul class="nav left-menu">
+          <li class="menu-title">
+            <a href="/docs/ionic-cli-faq/">FAQ</a>
+          </li>
+        </ul>
+
+      </div>
+
+    </div>
+
+    <div class="col-md-10 col-sm-9 main-content">
+      {{ content }}
+    </div>
+
+  </div>
+
+</div>
+
+<div class="pre-footer">
+
+  <div class="row ionic">
+
+    <div class="col-sm-6 col-a">
+      <h4>
+        <a href="/docs/guide/">Read the Book <span class="icon ion-arrow-right-c"></span></a>
+      </h4>
+      <p>
+        A walk through of getting Ionic installed, creating a new project, building the UI, adding logic, testing, deploying on the device, and publishing to various app stores.
+      </p>
+    </div>
+
+    <div class="col-sm-6 col-b">
+      <h4>
+        <a href="http://forum.ionicframework.com/">Community Forum <span class="icon ion-arrow-right-c"></span></a>
+      </h4>
+      <p>
+        Discuss and share ideas, hacks, and questions with others building with Ionic on the official Ionic Forum. Stop by and say Hello!
+      </p>
+    </div>
+
+  </div>
+
+</div>
+
+{% include footer.html %}
+
+{% include base_scripts.html %}
+
+</body>
+</html>

--- a/_layouts/docs_css.html
+++ b/_layouts/docs_css.html
@@ -128,6 +128,12 @@
 
             <ul class="nav left-menu">
               <li class="menu-title">
+                <a href="/docs/cli/">CLI</a>
+              </li>
+            </ul>
+
+            <ul class="nav left-menu">
+              <li class="menu-title">
                 <a href="http://learn.ionicframework.com/">Learn Ionic</a>
               </li>
             </ul>

--- a/_layouts/docs_faq.html
+++ b/_layouts/docs_faq.html
@@ -39,6 +39,12 @@
 
           <ul class="nav left-menu">
             <li class="menu-title">
+              <a href="/docs/cli/">CLI</a>
+            </li>
+          </ul>
+
+          <ul class="nav left-menu">
+            <li class="menu-title">
               <a href="http://learn.ionicframework.com/">Learn Ionic</a>
             </li>
           </ul>

--- a/_layouts/docs_guide.html
+++ b/_layouts/docs_guide.html
@@ -40,6 +40,12 @@
 
             <ul class="nav left-menu">
               <li class="menu-title">
+                <a href="/docs/cli/">CLI</a>
+              </li>
+            </ul>
+
+            <ul class="nav left-menu">
+              <li class="menu-title">
                 <a href="http://learn.ionicframework.com/">Learn Ionic</a>
               </li>
             </ul>

--- a/_layouts/docs_home.html
+++ b/_layouts/docs_home.html
@@ -40,6 +40,12 @@
 
             <ul class="nav left-menu">
               <li class="menu-title">
+                <a href="/docs/cli/">CLI</a>
+              </li>
+            </ul>
+
+            <ul class="nav left-menu">
+              <li class="menu-title">
                 <a href="http://learn.ionicframework.com/">Learn Ionic</a>
               </li>
             </ul>

--- a/_layouts/docs_overview.html
+++ b/_layouts/docs_overview.html
@@ -50,6 +50,12 @@
 
             <ul class="nav left-menu">
               <li class="menu-title">
+                <a href="/docs/cli/">CLI</a>
+              </li>
+            </ul>
+
+            <ul class="nav left-menu">
+              <li class="menu-title">
                 <a href="http://learn.ionicframework.com/">Learn Ionic</a>
               </li>
             </ul>

--- a/docs/cli/icon-splashscreen.md
+++ b/docs/cli/icon-splashscreen.md
@@ -1,0 +1,51 @@
+---
+layout: docs_cli
+title: "Ionic CLI"
+header_title:  Add Icons and Splash Screens
+header_sub_title: The powerful command line utility
+---
+
+
+# Icon and Splash Screen Image Generation
+
+[Automatically generate icons and splash screens](http://ionicframework.com/blog/automating-icons-and-splash-screens/) from source images to create each size needed for each platform, in addition to copying each resized and cropped image into each platform's resources directory. Source images can either be a `png`, `psd` __Photoshop__ or `ai` __Illustrator__ file. Images are generated using Ionic's image resizing and cropping server, instead of requiring special libraries and plugins to be installed locally.
+
+Since each platform has different image requirements, it's best to make a source image for the largest size needed, and let the CLI do all the resizing, cropping and copying for you. Newly generated images will be placed in the `resources` directory at the root of the Cordova project. Additionally, the CLI will update and add the correct `<platform>` configs to the project's [config.xml](http://cordova.apache.org/docs/en/edge/config_ref_images.md.html#Icons%20and%20Splash%20Screens) file.
+
+During the build process, Cordova (v3.6 or later) will look through the project's [config.xml](http://cordova.apache.org/docs/en/edge/config_ref_images.md.html#Icons%20and%20Splash%20Screens) file and copy the newly created resource images to the platform's specific resource folder. For example, Android's resource folder can be found in `platforms/android/res`, and iOS uses `platforms/ios/APP_NAME/Resources`.
+
+
+### Icon Source Image
+
+Save an `icon.png`, `icon.psd` or `icon.ai` file within the `resources` directory at the root of the Cordova project. The icon image's minimum dimensions should be 192x192 px, and should have __no__ rounded corners. Note that each platform will apply it's own mask and effects to the icons. For example, iOS will automatically apply it's custom rounded corners, so the source file should not already come with rounded corners. This [Photoshop icon template](http://code.ionicframework.com/resources/icon.psd) provides the recommended size and guidelines of the artwork's safe zone.
+
+```bash
+$ ionic resources --icon
+```
+
+- [Photoshop Icon Template](http://code.ionicframework.com/resources/icon.psd)
+
+
+### Splash Screen Source Image
+
+Save a `splash.png`, `splash.psd` or `splash.ai` file within the `resources` directory at the root of the Cordova project. Splash screen dimensions vary for each platform, device and orientation, so a square source image is required the generate each of various sizes. The source image's minimum dimensions should be 2208x2208 px, and its artwork should be centered within the square, knowning that each generated image will be center cropped into landscape and portait images. The splash screen's artwork should roughly fit within a center square (1200x1200 px). This [Photoshop splash screen template](http://code.ionicframework.com/resources/splash.psd) provides the recommended size and guidelines of the artwork's safe zone. Additionally, when the `Orientation` [preference config](http://cordova.apache.org/docs/en/edge/config_ref_index.md.html#The%20config.xml%20File_global_preferences) is set to either `landscape` or `portrait` mode, then only the necessary images will be generated.
+
+```bash
+$ ionic resources --splash
+```
+
+- [Photoshop Splash Screen Template](http://code.ionicframework.com/resources/splash.psd)
+
+
+### Generating Icons and Splash Screens
+
+To generate both icons and splash screens, follow the instructions above and run:
+
+```bash
+$ ionic resources
+```
+
+### Platform Specific Resource Images
+
+One source image can be used to generate images for each platform by placing the file within the `resources` directory, such as `resources/icon.png`. To use different source images for individual platforms, place the source image in the respective platform's directory. For example, to use a different icon for Android, it should follow this path: `resources/android/icon.png`, and a different image for iOS would use this path: `resources/ios/icon.png`.
+

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,0 +1,10 @@
+---
+layout: docs_cli
+title: "Ionic CLI"
+header_title: Ionic CLI
+header_sub_title: The powerful command line utility
+---
+
+The Ionic Framework command line utility makes it easy to start, build, run, and emulate Ionic apps. In the future, it will also have support for our mobile development services and tools that make Ionic even more powerful.
+
+Use the ionic --help command for more detailed task information.

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -1,0 +1,29 @@
+---
+layout: docs_cli
+title: "Ionic CLI"
+header_title: Installing the CLI globally
+header_sub_title: The powerful command line utility
+---
+
+# Install the Ionic CLI
+
+The easiest way to get the Ionic CLI is through [npm](https://www.npmjs.com/).
+
+```bash
+$ npm install -g ionic
+```
+
+*Note: For a global install of -g ionic, OSX/Linux users may need to prefix the command with sudo.*
+
+
+## Update Ionic lib
+
+Update Ionic library files, which are found in the `www/lib/ionic` directory. If bower is being used
+by the project, this command will automatically run `bower update ionic`, otherwise this command updates
+the local static files from Ionic's CDN.
+
+```bash
+$ ionic lib update
+```
+
+*Note: Using bower? This command does not update Ionic's dependencies. Run `bower update` to update Ionic and all of it's dependencies defined in `bower.json`.*

--- a/docs/cli/package.md
+++ b/docs/cli/package.md
@@ -1,0 +1,10 @@
+---
+layout: docs_cli
+title: "Ionic CLI"
+header_title: Ionic CLI - Start a New App
+header_sub_title: An overview of Ionic, why we built it, how to use it, and what you should know along the way
+---
+
+The Ionic Framework command line utility makes it easy to start, build, run, and emulate Ionic apps. In the future, it will also have support for our mobile development services and tools that make Ionic even more powerful.
+
+Use the ionic --help command for more detailed task information.

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -1,0 +1,62 @@
+---
+layout: docs_cli
+title: "Ionic CLI"
+header_title:  Run & Emulate on your Phone
+header_sub_title: The powerful command line utility
+---
+
+## Adding a platform target
+
+```bash
+$ ionic platform ios android
+```
+
+## Building your app
+
+```bash
+$ ionic build ios
+```
+
+## Live Reload App During Development (beta)
+
+The `run` or `emulate` command will deploy the app to the specified platform devices/emulators. You can also run __live reload__ on the specified platform device by adding the `--livereload` option. The live reload functionality is similar to `ionic serve`, but instead of developing and debugging an app using a standard browser, the compiled hybrid app itself is watching for any changes to its files and reloading the app when needed. This reduces the requirement to constantly rebuild the app for small changes. However, any changes to plugins will still require a full rebuild. For live reload to work, the dev machine and device must be on the same local network, and the device must support [web sockets](http://caniuse.com/websockets).
+
+With live reload enabled, an app's console logs can also be printed to the terminal/command prompt by including the `--consolelogs` or `-c` option. Additionally, the development server's request logs can be printed out using `--serverlogs` or `-s` options.
+
+### Command-line flags/options for `run` and `emulate`
+
+```
+[--livereload|-l] .......  Live Reload app dev files from the device (beta)
+[--consolelogs|-c] ......  Print app console logs to Ionic CLI (live reload req.)
+[--serverlogs|-s] .......  Print dev server logs to Ionic CLI (live reload req.)
+[--port|-p] .............  Dev server HTTP port (8100 default, live reload req.)
+[--livereload-port|-i] ..  Live Reload port (35729 default, live reload req.)
+[--debug|--release]
+```
+
+While the server is running for live reload, you can use the following commands within the CLI:
+
+```
+restart or r to restart the client app from the root
+goto or g and a url to have the app navigate to the given url
+consolelogs or c to enable/disable console log output
+serverlogs or s to enable/disable server log output
+quit or q to shutdown the server and exit
+```
+
+## Emulating your app
+
+Deploys the Ionic app on specified platform emulator. This is simply an alias for `run --emulator`.
+
+```bash
+$ ionic emulate ios [options]
+```
+
+
+## Running your app
+
+Deploys the Ionic app on specified platform devices. If a device is not found it'll then deploy to an emulator/simulator.
+
+```bash
+$ ionic run ios [options]
+```

--- a/docs/cli/sass.md
+++ b/docs/cli/sass.md
@@ -1,0 +1,24 @@
+---
+layout: docs_cli
+title: "Ionic CLI"
+header_title: Setting up Sass
+header_sub_title: The powerful command line utility
+---
+
+# Using Sass
+
+By default, starter projects are hooked up to Ionic's precompiled CSS file, which is found in the project's `www/lib/ionic/css` directory, and is linked to the app in the head of the root `index.html` file. However, Ionic projects can also be customized using [Sass](http://sass-lang.com/), which gives developers and designers "superpowers" in terms of creating and maintaining CSS. Below are two ways to setup Sass for your Ionic project (the `ionic setup sass` command simply does the manual steps for you). Once Sass has been setup for your Ionic project, then the `ionic serve` command will also watch for Sass changes.
+
+#### Setup Sass Automatically
+
+```bash
+$ ionic setup sass
+```
+
+#### Setup Sass Manually
+
+1. Run `npm install` from the working directory of an Ionic project. This will install [gulp.js](http://gulpjs.com/) and a few handy tasks, such as [gulp-sass](https://www.npmjs.org/package/gulp-sass) and [gulp-minify-css](https://www.npmjs.org/package/gulp-minify-css).
+2. Remove `<link href="lib/ionic/css/ionic.css" rel="stylesheet">` from the `<head>` of the root `index.html` file.
+3. Remove `<link href="css/style.css" rel="stylesheet">` from the `<head>` of the root `index.html` file.
+4. Add `<link href="css/ionic.app.css" rel="stylesheet">` to the `<head>` of the root `index.html` file.
+5. In the `ionic.project` file, add the JavaScript property `"gulpStartupTasks": ["sass", "watch"]` (this can also be customized to whatever gulp tasks you'd like).

--- a/docs/cli/start.md
+++ b/docs/cli/start.md
@@ -1,0 +1,49 @@
+---
+layout: docs_cli
+title: "Ionic CLI"
+header_title: Start a new Ionic App
+header_sub_title: The powerful command line utility
+---
+
+# Starting an Ionic App
+
+```bash
+$ ionic start myapp [template]
+```
+
+Starter templates can either come from a named template, a Github repo, a Codepen, or a local directory. A starter template is what becomes the `www` directory within the Cordova project.
+
+
+### Named template starters
+
+* [tabs](https://github.com/driftyco/ionic-starter-tabs) (Default)
+* [sidemenu](https://github.com/driftyco/ionic-starter-sidemenu)
+* [blank](https://github.com/driftyco/ionic-starter-blank)
+
+
+### Github Repo starters
+
+* Any Github repo url, ex: [https://github.com/driftyco/ionic-starter-tabs](https://github.com/driftyco/ionic-starter-tabs)
+* Named templates are simply aliases to Ionic starter repos
+
+
+### Codepen URL starters
+
+* Any Codepen url, ex: [http://codepen.io/ionic/pen/odqCz](http://codepen.io/ionic/pen/odqCz)
+* [Ionic Codepen Demos](http://codepen.io/ionic/public-list/)
+
+
+### Local directory starters:
+
+* Relative or absolute path to a local directory
+
+
+### Command-line flags/options:
+
+```
+--appname, -a  .......  Human readable name for the app
+                        (Use quotes around the name)
+--id, -i  ............  Package name set in the <widget id> config
+                        ex: com.mycompany.myapp
+--no-cordova, -w  ....  Do not create an app targeted for Cordova
+```

--- a/docs/cli/test.md
+++ b/docs/cli/test.md
@@ -1,0 +1,74 @@
+---
+layout: docs_cli
+title: "Ionic CLI"
+header_title: Testing and Live Development
+header_sub_title: The powerful command line utility
+---
+
+
+# Testing in a Browser
+
+Use `ionic serve` to start a local development server for app dev and testing. This is useful for both desktop browser testing, and to test within a device browser which is connected to the same network. Additionally, this command starts LiveReload which is used to monitor changes in the file system. As soon as you save a file the browser is refreshed automatically. View [Using Sass](https://github.com/driftyco/ionic-cli/blob/master/README.md#using-sass) if you would also like to have `ionic serve` watch the project's Sass files.
+
+```bash
+$ ionic serve [options]
+```
+
+### Service Proxies
+
+The `serve` command can add some proxies to the http server. These proxies are useful if you are developing in the browser and you need to make calls to an external API. With this feature you can proxy request to the external api through the ionic http server preventing the `No 'Access-Control-Allow-Origin' header is present on the requested resource` error.
+
+In the `ionic.project` file you can add a property with an array of proxies you want to add. The proxies are object with two properties:
+
+* `path`: string that will be matched against the beginning of the incoming request URL.
+* `proxyUrl`: a string with the url of where the proxied request should go.
+
+```json
+{
+  "name": "appname",
+  "email": "",
+  "app_id": "",
+  "proxies": [
+    {
+      "path": "/v1",
+      "proxyUrl": "https://api.instagram.com/v1"
+    }
+  ]
+}
+```
+
+Using the above configuration, you can now make requests to your local server at `http://localhost:8100/v1` to have it proxy out requests to `https://api.instagram.com/v1`
+
+For example:
+
+```js
+angular.module('starter.controllers', [])
+.constant('InstagramApiUrl', '')
+// .contant('InstagramApiUrl','https://api.instagram.com')
+//In production, make this the real URL
+
+.controller('FeedCtrl', function($scope, $http, InstagramApiUrl) {
+
+  $scope.feed = null;
+
+  $http.get(InstagramApiUrl + '/v1/media/search?client_id=1&lat=48&lng=2.294351').then(function(data) {
+    console.log('data ' , data)
+    $scope.feed = data;
+  })
+
+})
+```
+
+See also [this gist](https://gist.github.com/jbavari/d9c1c94058c4fdd4e935) for more help.
+
+### Command-line flags/options
+
+```
+[--consolelogs|-c] ......  Print app console logs to Ionic CLI
+[--serverlogs|-s] .......  Print dev server logs to Ionic CLI
+[--port|-p] .............  Dev server HTTP port (8100 default)
+[--livereload-port|-i] ..  Live Reload port (35729 default)
+[--nobrowser|-b] ........  Disable launching a browser
+[--nolivereload|-r] .....  Do not start live reload
+[--noproxy|-x] ..........  Do not add proxies
+```


### PR DESCRIPTION
Adds CLI documentation to the Ionic/docs.

Needs some improvement for UI (spacing of headers + more).

Did this after a discussion with @jbavari  in https://github.com/driftyco/ionic-cli/issues/169

Looks like this:


![screen shot 2015-01-08 at 6 15 08 pm](https://cloud.githubusercontent.com/assets/1716394/5672835/58618acc-9762-11e4-97d2-f9e28de25981.jpg)
