### PR TITLE
Add the  documentation in ionic CLI /docs/cli/test.md

### DIFF
--- a/docs/cli/test.md
+++ b/docs/cli/test.md
@@ -31,6 +31,7 @@ property in the `ionic.project` file located in your project root to watch
 {
   "name": "myApp",
   "app_id": "",
+  "default_browser": "chrome", // must be in your path
   "watchPatterns": [
     "www/js/*",
     "!www/css/**/*"


### PR DESCRIPTION
This option wasn't documented at all yet.

(see https://github.com/driftyco/ionic-cli/issues/328)