### PR TITLE
docs: fix platform guide links

### DIFF
--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -26,7 +26,7 @@ pre_footer: true
       <div class="desc">
         <h3>Install Ionic</h3>
         <p>
-        First, install <a href="http://nodejs.org/">Node.js</a>. Then, install the latest Cordova and Ionic <a href="https://npmjs.org/package/ionic">command-line tools</a>. Follow the <a href="http://cordova.apache.org/docs/en/3.3.0/guide_platforms_android_index.md.html#Android%20Platform%20Guide">Android</a> and <a href="http://cordova.apache.org/docs/en/3.3.0/guide_platforms_ios_index.md.html#iOS%20Platform%20Guide">iOS</a> platform guides to install required platform dependencies.
+        First, install <a href="http://nodejs.org/">Node.js</a>. Then, install the latest Cordova and Ionic <a href="https://npmjs.org/package/ionic">command-line tools</a>. Follow the <a href="http://cordova.apache.org/docs/en/3.3.0/guide/platforms/android/index.html">Android</a> and <a href="http://cordova.apache.org/docs/en/3.3.0/guide/platforms/ios/index.html">iOS</a> platform guides to install required platform dependencies.
         <!--Windows users: we strongly recommend <a href="http://visualstudio.com/">Visual Studio Community</a> for development which comes with everything you need.-->
         <p>
         <i>


### PR DESCRIPTION
Links to the Cordova Android and iOS platform guides were broken and are now fixed.