### PR TITLE
Typo fix in v2 migration docs, $statProvider -> $stateProvider

### DIFF
--- a/docs/v2/getting-started/migration/index.md
+++ b/docs/v2/getting-started/migration/index.md
@@ -19,8 +19,8 @@ Take this V1 example.
 V1
 
 ```
-.config(function($statProvider){
-  $statProvider
+.config(function($stateProvider){
+  $stateProvider
   .state('main', {
     url: '/',
     templateUrl: 'templates/main.html',


### PR DESCRIPTION
Just a simple typo fix in v2 docs...