### PR TITLE
Fix header for docs/concepts/structure.md

### DIFF
--- a/docs/concepts/structure.md
+++ b/docs/concepts/structure.md
@@ -5,7 +5,7 @@ header_title: Ionic Concepts
 header_sub_title: The bigger picture of an Ionic App
 ---
 
-###Structure
+### Structure
 Ionic apps are built with Cordova. Cordova is a means of packaging html/css/js into apps that can run on mobile and desktop devices and provides a plugin architecture for accessing native functionality beyond the reach of JS run from a web browser. As such, Ionic apps have the Cordova file structure. 
 
 The `platforms` directory contains your iOS and Android projects. In general, you don’t need to work in these directories unless you're doing custom native hacking or possibly sending your app to production.


### PR DESCRIPTION
Markdown didn't have proper spacing for the header, resulting in improper output on the actual site.
![screen shot 2015-11-18 at 1 55 07 pm](https://cloud.githubusercontent.com/assets/3712117/11252476/00fe46a8-8dfc-11e5-9ded-d4cc2f6e178b.png)