### PR TITLE
Removed unsupported tabs from card showcase

### DIFF
--- a/docs/components/index.html
+++ b/docs/components/index.html
@@ -1673,21 +1673,6 @@ search_sections: true
     </p>
   </div>
 
-  <div class="item tabs tabs-secondary tabs-icon-left">
-    <a class="tab-item" href="#">
-      <i class="icon ion-thumbsup"></i>
-      Like
-    </a>
-    <a class="tab-item" href="#">
-      <i class="icon ion-chatbox"></i>
-      Comment
-    </a>
-    <a class="tab-item" href="#">
-      <i class="icon ion-share"></i>
-      Share
-    </a>
-  </div>
-
 </div>
 {% endhighlight %}
 
@@ -1716,21 +1701,6 @@ search_sections: true
             <a href="#" class="subdued">1 Like</a>
             <a href="#" class="subdued">5 Comments</a>
           </p>
-        </div>
-
-        <div class="item tabs tabs-secondary tabs-icon-left">
-          <a class="tab-item" href="#">
-            <i class="icon ion-thumbsup"></i>
-            Like
-          </a>
-          <a class="tab-item" href="#">
-            <i class="icon ion-chatbox"></i>
-            Comment
-          </a>
-          <a class="tab-item" href="#">
-            <i class="icon ion-share"></i>
-            Share
-          </a>
         </div>
 
       </div>


### PR DESCRIPTION
As per @mlynch 's comment on https://github.com/driftyco/ionic/pull/3737, tabs are not supported in cards. This removes them from the documentation so that people don't get confused.