### PR TITLE
Fixed css of anchor tag

### DIFF
--- a/_scss/docs/main.scss
+++ b/_scss/docs/main.scss
@@ -21,7 +21,7 @@ body {
 .improve-docs {
   position: absolute;
   right: 3.5em;
-  top: 8em;
+  top: 1em;
 }
 .docs-container {
   .side-nav {

--- a/css/v2.css
+++ b/css/v2.css
@@ -4547,7 +4547,7 @@ body {
 .improve-docs {
   position: absolute;
   right: 3.5em;
-  top: 8em; }
+  top: 1em; }
 
 .docs-container .side-nav {
   width: 230px;

--- a/css/v2.css
+++ b/css/v2.css
@@ -4547,7 +4547,7 @@ body {
 .improve-docs {
   position: absolute;
   right: 3.5em;
-  top: 1em; }
+  top: 8em; }
 
 .docs-container .side-nav {
   width: 230px;


### PR DESCRIPTION

The "Improve this doc" anchor tag was overlapping the tutorial text. Fixed this by moving it up higher on the page.

Before:
![improve-doc-overlap](https://cloud.githubusercontent.com/assets/7282254/11824288/a38e4a62-a32d-11e5-93e0-8a67d2a5ab6b.png)

After:
![improve-doc-overlap-fix](https://cloud.githubusercontent.com/assets/7282254/11824292/a6cf8e7a-a32d-11e5-9bfe-7f3c5b3bf152.png)