### PR TITLE
Updated cordova section to include asset install

### DIFF
--- a/docs/overview/index.html
+++ b/docs/overview/index.html
@@ -112,6 +112,11 @@ $ ionic start myproject
     To add Ionic to your <a href="http://cordova.apache.org/">Cordova</a>, <a href="http://phonegap.com/">PhoneGap</a>, or <a href="https://trigger.io/">Trigger.io</a> project, just reference the Ionic CSS and JS files from the web root of your app.
   </p>
 
+  <p>
+    The CSS and JS files can be found in the <a href="https://www.npmjs.com/package/ionic-sdk">ionic-sdk</a> npm package. 
+    You can also download them directly at <a href="http://code.ionicframework.com/">http://code.ionicframework.com/</a> or in the github repo: <a href="http://code.ionicframework.com/">https://github.com/driftyco/ionic</a>. The release directory will have the files you need: <a href="https://github.com/driftyco/ionic/tree/master/release">https://github.com/driftyco/ionic/tree/master/release</a>. The "Manual Start" section of the README also goes through some other ways to install.
+  </p>
+
 </section>
 
 


### PR DESCRIPTION
The Cordova section in the Overview did not thoroughly explain where to get the CSS and JS files for manual install.

Resolves driftyco/ionic#4433