### PR TITLE
tutorials(icons): rename <icon> to <ion-icon>

### DIFF
--- a/docs/v2/getting-started/tutorial/adding-pages/index.md
+++ b/docs/v2/getting-started/tutorial/adding-pages/index.md
@@ -96,7 +96,7 @@ All pages have both a class, and an associated template. Let's checkout `app/hel
 {% raw %}
 <ion-navbar *navbar>
   <a menu-toggle>
-    <icon menu></icon>
+    <ion-icon name="menu"></ion-icon>
   </a>
   <ion-title>Hello Ionic</ion-title>
 </ion-navbar>


### PR DESCRIPTION
icon tag name changed to ion-icon
PR #328 has missed tutorial page