### PR TITLE
Fix icon-list to use ion-icon

### DIFF
--- a/_includes/v2_fluid/component-docs/lists.html
+++ b/_includes/v2_fluid/component-docs/lists.html
@@ -93,9 +93,9 @@ Adding [icons](#icons) to list items is a great way to hint about the contents o
 ```html
 <ion-list>
   <ion-item>
-    <icon leaf item-left></icon>
+    <ion-icon leaf item-left></ion-icon>
       Herbology
-    <icon rose item-right></icon>
+    <ion-icon rose item-right></ion-icon>
   </ion-item>
 </ion-list>
 ```


### PR DESCRIPTION
Swap icon with ion-icon, not sure if the icon name also needs to be inside a name attribute as stated in the deprecated warning !?