### PR TITLE
Fix navigation link

### DIFF
--- a/docs/v2/getting-started/tutorial/navigation/index.md
+++ b/docs/v2/getting-started/tutorial/navigation/index.md
@@ -44,7 +44,7 @@ After saving the file, you will notice the `ionic serve` process will recompile 
 
 ### How It Works
 
-Navigation in Ionic 2 works like a simple stack, where we `push` new pages onto the top of the stack, which takes us forwards in the app and shows a back button. To go backwards, we `pop` the top page off. Since we set `this.nav` in the constructor, we can call `this.nav.push()`, and pass it the page we want to navigate to. We can also pass it an object containing data we would like to pass to the page being navigated to. Using `push` to navigate to a new page is simple, but Ionic's [navigation system](../../../components/navigation) is very flexible. Check out the [navigation docs](../../../components/navigation) to see more advanced navigation examples.
+Navigation in Ionic 2 works like a simple stack, where we `push` new pages onto the top of the stack, which takes us forwards in the app and shows a back button. To go backwards, we `pop` the top page off. Since we set `this.nav` in the constructor, we can call `this.nav.push()`, and pass it the page we want to navigate to. We can also pass it an object containing data we would like to pass to the page being navigated to. Using `push` to navigate to a new page is simple, but Ionic's [navigation system](../../../components/navigation) is very flexible. Check out the [navigation docs](../../../components/#navigation) to see more advanced navigation examples.
 
 
 <button type="button" class="btn btn-primary btn-sm" data-toggle="collapse" data-target="#v1-changes">


### PR DESCRIPTION
The navigation docs link is currently "`[navigation docs](../../../components/navigation)`", but that page does not exist. "`[navigation docs](../../../components/#navigation)`" does though.