### PR TITLE
Fixed doc for ion-toolbar footer

### DIFF
--- a/_includes/v2_fluid/component-docs/toolbar.html
+++ b/_includes/v2_fluid/component-docs/toolbar.html
@@ -26,7 +26,7 @@ Add the property `position="bottom"` to place the tool bar below the content
 ```html
 <ion-content></ion-content>
 
-<ion-toolbar position="toolbar">
+<ion-toolbar position="bottom">
   <ion-title>Footer</ion-title>
 </ion-toolbar>
 ```


### PR DESCRIPTION
Changed position from `toolbar` to `bottom`