### PR TITLE
Overriding Ionic Variables doc link broken

### DIFF
--- a/docs/v2/theming/sass-variables/index.md
+++ b/docs/v2/theming/sass-variables/index.md
@@ -47,4 +47,4 @@ This is extremely useful if you decide later on that you would like to change th
 
 Sass variables go hand in hand with Ionic. With some CSS frameworks, you have to create a new stylesheet and override their styles to change the look of your application. In Ionic, you can modify the Sass directly, so that the CSS file that gets generated has the customization you want.
 
-Learn how you can override Ionic's Sass variables in order to get a custom style for your app in the [next section](../overriding-ionic/).
+Learn how you can override Ionic's Sass variables in order to get a custom style for your app in the [next section](../overriding-ionic-variables/).


### PR DESCRIPTION
Link at bottom is broken (currently directs to 'overriding-ionic/', but the doc actually resides at 'overriding-ionic-variables/').