### PR TITLE
docs: fix Demo Source button going to wrong url

### DIFF
--- a/_includes/v2_fluid/component-docs/lists.html
+++ b/_includes/v2_fluid/component-docs/lists.html
@@ -164,7 +164,7 @@ Multiline lists are identical to regular lists, except they can multiple lines o
 ```
 
 <h3 class="section-nav" id="sliding-list">Sliding List</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/lists/thumbnail">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/lists/sliding">
   Demo Source
 </a>
 


### PR DESCRIPTION
Demo Source button was going to wrong url, now goes to correct url, this is for issue #481 