### PR TITLE
Fix template syntax with controllerAs syntax

### DIFF
--- a/docs/v2/getting-started/migration/index.md
+++ b/docs/v2/getting-started/migration/index.md
@@ -90,7 +90,7 @@ _index.html_
 {% raw %}
     <ion-content ng-controller="MainCtrl as main">
       <ion-item>
-        {{data.text}}
+        {{main.data.text}}
       </ion-item>
     </ion-content>
 {% endraw %}


### PR DESCRIPTION
When using `controllerAs` syntax, all variables in the template need to be scoped under the controller alias. Example can be found here - https://plnkr.co/edit/hBMlm30GjYd2XNP1srnP?p=preview