### PR TITLE
Change ng-for to ngFor

### DIFF
--- a/docs/v2/getting-started/tutorial/project-structure/index.md
+++ b/docs/v2/getting-started/tutorial/project-structure/index.md
@@ -77,7 +77,7 @@ Here's the main template for the app in `app/app.html`:
 
   <ion-content>
     <ion-list>
-      <button ion-item *ng-for="#p of pages" (click)="openPage(p)">
+      <button ion-item *ngFor="#p of pages" (click)="openPage(p)">
         {% raw %}{{p.title}}{% endraw %}
       </button>
     </ion-list>


### PR DESCRIPTION
While trying out the tutorial I got an error caused by using the old ```ng-for``` syntax.