### PR TITLE
fix: add proper install command

### DIFF
--- a/docs/v2/native/Push/index.md
+++ b/docs/v2/native/Push/index.md
@@ -41,7 +41,7 @@ docType: "class"
 <!-- decorators -->
 
 
-<pre><code>$ cordova plugin add phonegap-plugin-push</code></pre>
+<pre><code>$ ionic plugin add phonegap-plugin-push --variable SENDER_ID="XXXXXXX"</code></pre>
 <p>Repo:
   <a href="https://github.com/phonegap/phonegap-plugin-push">
     https://github.com/phonegap/phonegap-plugin-push


### PR DESCRIPTION
It should be `ionic plugin` so it can be saved in package.json. It also needs the flags, they are a requirement.