### PR TITLE
Removed active project scoping.

### DIFF
--- a/docs/guide/building.md
+++ b/docs/guide/building.md
@@ -49,7 +49,7 @@ With the list code and the Angular `ng-repeat`, the center content becomes:
   <ion-content>
     <!-- our list and list items -->
     <ion-list>
-      <ion-item ng-repeat="task in activeProject.tasks">
+      <ion-item ng-repeat="task in tasks">
         {{task.title}}
       </ion-item>
     </ion-list>


### PR DESCRIPTION
Removed active project scoping as projects haven't been added yet at this point in the guide.  The very next section correctly has ```ng-repeat="task in tasks"```.