### PR TITLE
Fixed unclosed <a> html tag for what-is/polyfill

### DIFF
--- a/docs/v2/resources/what-is/index.md
+++ b/docs/v2/resources/what-is/index.md
@@ -143,7 +143,7 @@ header_sub_title: Ionic Resources
 <section id="polyfill">
     <h3><a href="#polyfill">Polyfill</a></h3>
     <p>A polyfill is a bit of code that add functionality to the browser and normalizes browser differences. This is similar to a shim, but where as a shim has it's own API, a polyfill let's you use the expect API of the brower.</p>
-    <p><a href="https://remysharp.com/2010/10/08/what-is-a-polyfill">What is a polyfill?</p>
+    <p><a href="https://remysharp.com/2010/10/08/what-is-a-polyfill">What is a polyfill?</a></p>
   </section>
 
 <section id="protractor">


### PR DESCRIPTION
An unclosed <a> html tag is causing for html to show broken tags in webpage.