### PR TITLE
Clean up confusion with Event arguments

### DIFF
--- a/docs/v2/api/util/Events/index.md
+++ b/docs/v2/api/util/Events/index.md
@@ -61,8 +61,9 @@ function createUser(user) {
 }
 
 // second page (listen for the user created event)
-events.subscribe(&#39;user:created&#39;, (user) =&gt; {
-  console.log(&#39;Welcome&#39;, user);
+events.subscribe(&#39;user:created&#39;, (userEventData) =&gt; {
+  // userEventData is an array of parameters, so grab our first and only arg
+  console.log(&#39;Welcome&#39;, userEventData[0]);
 });
 </code></pre>
 


### PR DESCRIPTION
Addresses part of https://github.com/driftyco/ionic-site/issues/544.

This PR makes it so that the piece of code in the docs works as intended. Otherwise, the second `console.log` statement will result in an array output, instead of the intended user object.