### PR TITLE
Box bracket value attributes

### DIFF
--- a/_includes/v2_fluid/component-docs/select.html
+++ b/_includes/v2_fluid/component-docs/select.html
@@ -18,12 +18,12 @@ The `ion-select` component is similar to an HTML `<select>` element, however, Io
   <ion-item>
     <ion-label>Gaming</ion-label>
     <ion-select [(ngModel)]="gaming">
-      <ion-option value="nes">NES</ion-option>
-      <ion-option value="n64">Nintendo64</ion-option>
-      <ion-option value="ps">PlayStation</ion-option>
-      <ion-option value="genesis">Sega Genesis</ion-option>
-      <ion-option value="saturn">Sega Saturn</ion-option>
-      <ion-option value="snes">SNES</ion-option>
+      <ion-option [value]="nes">NES</ion-option>
+      <ion-option [value]="n64">Nintendo64</ion-option>
+      <ion-option [value]="ps">PlayStation</ion-option>
+      <ion-option [value]="genesis">Sega Genesis</ion-option>
+      <ion-option [value]="saturn">Sega Saturn</ion-option>
+      <ion-option [value]="snes">SNES</ion-option>
     </ion-select>
   </ion-item>
 </ion-list>
@@ -37,16 +37,16 @@ You can make multiple selections with `<ion-select>` by adding `multiple="true"`
   <ion-item>
     <ion-label>Toppings</ion-label>
     <ion-select [(ngModel)]="toppings" multiple="true" cancelText="Nah" okText="Okay!">
-      <ion-option value="bacon" checked="true">Bacon</ion-option>
-      <ion-option value="olives">Black Olives</ion-option>
-      <ion-option value="xcheese" checked="true">Extra Cheese</ion-option>
-      <ion-option value="peppers">Green Peppers</ion-option>
-      <ion-option value="mushrooms">Mushrooms</ion-option>
-      <ion-option value="onions">Onions</ion-option>
-      <ion-option value="pepperoni">Pepperoni</ion-option>
-      <ion-option value="pineapple">Pineapple</ion-option>
-      <ion-option value="sausage">Sausage</ion-option>
-      <ion-option value="Spinach">Spinach</ion-option>
+      <ion-option [value]="bacon" checked="true">Bacon</ion-option>
+      <ion-option [value]="olives">Black Olives</ion-option>
+      <ion-option [value]="xcheese" checked="true">Extra Cheese</ion-option>
+      <ion-option [value]="peppers">Green Peppers</ion-option>
+      <ion-option [value]="mushrooms">Mushrooms</ion-option>
+      <ion-option [value]="onions">Onions</ion-option>
+      <ion-option [value]="pepperoni">Pepperoni</ion-option>
+      <ion-option [value]="pineapple">Pineapple</ion-option>
+      <ion-option [value]="sausage">Sausage</ion-option>
+      <ion-option [value]="Spinach">Spinach</ion-option>
     </ion-select>
   </ion-item>
 </ion-list>


### PR DESCRIPTION
The `value` input needs to be declared as an angular input property.
Update the docs to reflect the box bracket requirements.