### PR TITLE
Fix two Markdown link addresses.

### DIFF
--- a/docs/v2/getting-started/tutorial/project-structure/index.md
+++ b/docs/v2/getting-started/tutorial/project-structure/index.md
@@ -42,7 +42,7 @@ And the following scripts near the bottom:
 
 <h3 class="file-title">./app/app.js</h3>
 
-Inside of the `app` directory we find our pre-compiled code. This is where most of the work for an Ionic 2 app will take place. When we run `ionic serve`, our code inside of `app/` is [transpiled](docs/v2/resources/what-is/#transpiler) into the correct Javascript version that the browser understands (currently, [ES5](/docs/v2/resources/what-is/#es5)). That means we can work at a higher level using TypeScript and [ES6+](docs/v2/resources/what-is/#es2015-es6), but compile down to the older form of Javascript the browser needs.
+Inside of the `app` directory we find our pre-compiled code. This is where most of the work for an Ionic 2 app will take place. When we run `ionic serve`, our code inside of `app/` is [transpiled](/docs/v2/resources/what-is/#transpiler) into the correct Javascript version that the browser understands (currently, [ES5](/docs/v2/resources/what-is/#es5)). That means we can work at a higher level using TypeScript and [ES6+](/docs/v2/resources/what-is/#es2015-es6), but compile down to the older form of Javascript the browser needs.
 
 `app/app.js` is the entry point for our app.
 


### PR DESCRIPTION
The markdown links for `[transpiled](docs/v2/resources/what-is/#transpiler)` and `[ES6+](docs/v2/resources/what-is/#es2015-es6)` are missing the preceding `/`.
```
git grep -w '(docs/v2'
docs/v2/getting-started/tutorial/project-structure/index.md:Inside of the `app` directory we find our pre-compiled code. This is where most of the work for an Ionic 2 app will take place. When we run `ionic serve`, our code inside of `app/` is [transpiled](docs/v2/resources/what-is/#transpiler) into the correct Javascript version that the browser understands (currently, [ES5](/docs/v2/resources/what-is/#es5)). That means we can work at a higher level using TypeScript and [ES6+](docs/v2/resources/what-is/#es2015-es6), but compile down to the older form of Javascript the browser needs.

```