### PR TITLE
(Docs) Menus - remove App component

### DIFF
--- a/_includes/v2_fluid/component-docs/menus.html
+++ b/_includes/v2_fluid/component-docs/menus.html
@@ -24,7 +24,7 @@ To use a Menu add an [`<ion-menu>`](../api/components/menu/Menu/) to your markup
 </a>
 
 ```typescript
-@App({
+@Component({
   template: `
     <ion-menu [content]="content">
       <ion-toolbar>
@@ -49,14 +49,14 @@ class MyApp {}
 
 The `<ion-menu>`s bound `[content]` property gets a [reference](https://angular.io/docs/ts/latest/guide/user-input.html#local-variables) to the `<ion-nav>` in order to listen for drag events on the main content so it knows when to open/close.
 
-Then in our [@App](../api/config/App/) component we have two buttons with click handlers that navigate to a new root page:
+Then in our App component we have two buttons with click handlers that navigate to a new root page:
 
 ```typescript
-import {MenuController, IonicApp} from 'ionic-angular';
+import {MenuController, IonicApp, Component} from 'ionic-angular';
 import {LoginPage} from 'login';
 import {SignupPage} from 'signup';
 
-@App({
+@Component({
 ...
 })
 class MyApp {


### PR DESCRIPTION
The menus demo used the App decorator, which has been deprecated.

- Update examples to use Component in place of App
- Remove dead link to App component