### PR TITLE
encouraging installs without sudo with instructions on fixing EACCES error

### DIFF
--- a/docs/v2/getting-started/installation/index.md
+++ b/docs/v2/getting-started/installation/index.md
@@ -27,6 +27,8 @@ Make sure you have NodeJS installed. Download the installer [here](https://nodej
 
 > Unfamiliar with NPM? Learn more about it and what packages we use [here](/docs/v2/resources/using-npm/)
 
+> In case you get an **EACCES** error, it means node doesn't have write permissions to the global packages folder. Follow the instructions [here](https://docs.npmjs.com/getting-started/fixing-npm-permissions) to set the correct folder permissions.
+
 Worried about your V1 Ionic projects? Don't worry! The beta release has all the functionality to work with both V1 projects and V2 projects.
 
 Once that's done, create your first Ionic app:
@@ -50,7 +52,7 @@ You can play with it right in the browser!
 After you have Ionic installed, you can build your app to a physical device. If you don't have a physical device on hand, you can still build to a device emulator. Check out the <a href="../../resources/developer-tips/#using-ios-simulator">iOS simulator</a> docs if you are on a Mac, or the <a href="../../resources/developer-tips/#using-genymotion-android">Genymotion</a> docs if you are looking to emulate an Android device. You will also need <a href="../../resources/what-is/#cordova">Cordova</a> to run your app on a native device. To install Cordova, run:
 
 ```bash
-$ sudo npm install -g cordova
+$ npm install -g cordova
 ```
 
 Once you have Cordova installed and a device or emulator ready to go, you can move on and begin building your app!


### PR DESCRIPTION
I think its better to stay consistent with the two npm install commands. 
Moreover the new versions of node would give a warning when using sudo for installs.