### PR TITLE
fix(docs): Fixed some broken links to navbar

### DIFF
--- a/docs/v2/api/components/menu/Menu/index.md
+++ b/docs/v2/api/components/menu/Menu/index.md
@@ -64,7 +64,7 @@ type for iOS mode. The menu type can be changed in the app&#39;s <a href="../../
 via the <code>menuType</code> property, or passed in the <code>type</code> property on the <code>&lt;ion-menu&gt;</code> element.
 See <a href="#usage">usage</a> below for examples of changing the menu type.</p>
 <h3 id="navigation-bar-behavior">Navigation Bar Behavior</h3>
-<p>If a <a href="../MenuToggle">MenuToggle</a> button is added to the <a href="../../nav/NavBar">NavBar</a> of
+<p>If a <a href="../MenuToggle">MenuToggle</a> button is added to the <a href="../../navbar/NavBar">NavBar</a> of
 a page, the button will only appear when the page it&#39;s in is currently a root page. The
 root page is the initial page loaded in the app, or a page that has been set as the root
 using the <a href="../../nav/NavController/#setRoot">setRoot</a> method on the <a href="../../nav/NavController">NavController</a>.</p>
@@ -73,7 +73,7 @@ using the <a href="../../nav/NavController/#setRoot">setRoot</a> method on the <
 is <code>Page1</code>, making it the root page. <code>Page1</code> will display the <code>MenuToggle</code> button, but once
 <code>Page2</code> is pushed onto the navigation stack, the <code>MenuToggle</code> will not be displayed.</p>
 <h3 id="persistent-menus">Persistent Menus</h3>
-<p>Persistent menus display the <a href="../MenuToggle">MenuToggle</a> button in the <a href="../../nav/NavBar">NavBar</a>
+<p>Persistent menus display the <a href="../MenuToggle">MenuToggle</a> button in the <a href="../../navbar/NavBar">NavBar</a>
 on all pages in the navigation stack. To make a menu persistent set <code>persistent</code> to <code>true</code> on the
 <code>&lt;ion-menu&gt;</code> element. Note that this will only affect the <code>MenuToggle</code> button in the <code>NavBar</code> attached
 to the <code>Menu</code> with <code>persistent</code> set to true, any other <code>MenuToggle</code> buttons will not be affected.</p>

--- a/docs/v2/api/components/menu/MenuToggle/index.md
+++ b/docs/v2/api/components/menu/MenuToggle/index.md
@@ -45,7 +45,7 @@ Improve this doc
 
 
 <p>The <code>menuToggle</code> directive can be placed on any button to toggle a menu open or closed.
-If it is added to the <a href="../../nav/NavBar">NavBar</a> of a page, the button will only appear
+If it is added to the <a href="../../navbar/NavBar">NavBar</a> of a page, the button will only appear
 when the page it&#39;s in is currently a root page. See the <a href="../Menu#navigation-bar-behavior">Menu Navigation Bar Behavior</a>
 docs for more information.</p>
 

--- a/docs/v2/api/components/toolbar/Toolbar/index.md
+++ b/docs/v2/api/components/toolbar/Toolbar/index.md
@@ -45,7 +45,7 @@ Improve this doc
 
 
 <p>A Toolbar is a generic bar that is positioned above or below content.
-Unlike a <a href="../../nav/Navbar">Navbar</a>, a toolbar can be used as a subheader.
+Unlike a <a href="../../navbar/Navbar">Navbar</a>, a toolbar can be used as a subheader.
 When toolbars are placed within an <code>&lt;ion-header&gt;</code> or <code>&lt;ion-footer&gt;</code>,
 the toolbars stay fixed in their respective location. When placed within
 <code>&lt;ion-content&gt;</code>, toolbars will scroll with the content.</p>


### PR DESCRIPTION
The navbar api component is hosted at http://ionicframework.com/docs/v2/api/components/navbar/Navbar/, but some links still point to /nav/navBar. I've noticed broken links at the following api components:
- Menu
- MenuToggle
- Toolbar