### PR TITLE
fix: change <ion-nav> option 'swipe-back-enabled' to 'swipeBackEnabled'

### DIFF
--- a/docs/v2/getting-started/tutorial/adding-pages/index.md
+++ b/docs/v2/getting-started/tutorial/adding-pages/index.md
@@ -22,7 +22,7 @@ Now that we have a basic understanding of the layout of an Ionic 2 app, let's wa
 Taking a look at `app/app.html`, we see this line near the bottom:
 
 ```html
-<ion-nav id="nav" [root]="rootPage" #content swipe-back-enabled="false"></ion-nav>
+<ion-nav id="nav" [root]="rootPage" #content swipeBackEnabled="false"></ion-nav>
 ```
 
 Pay attention to the `[root]` property binding. This sets what is essentially the first, or "root" page for the `ion-nav` component. When `ion-nav` loads, the component referenced by the variable `rootPage` will be the root page.

--- a/docs/v2/getting-started/tutorial/project-structure/index.md
+++ b/docs/v2/getting-started/tutorial/project-structure/index.md
@@ -86,7 +86,7 @@ Here's the main template for the app in `app/app.html`:
 
 </ion-menu>
 
-<ion-nav id="nav" [root]="rootPage" #content swipe-back-enabled="false"></ion-nav>
+<ion-nav id="nav" [root]="rootPage" #content swipeBackEnabled="false"></ion-nav>
 ```
 
 In this template, we set up an [`ion-menu`](/docs/v2/components/#menus) to function as a side menu, and then an [`ion-nav`](/docs/v2/api/components/nav/Nav/) component to act as the main content area. The [`ion-menu`](/docs/v2/components/#menus)'s `[content]` property is bound to the local variable `content` from our [`ion-nav`](/docs/v2/api/components/nav/Nav/), so it knows where it should animate around.


### PR DESCRIPTION
`<ion-nav>` accepts `swipeBackEnabled`,  not `swipe-back-enabled`.

Related issue: https://github.com/driftyco/ionic/issues/5653

Also pull-requested to [ionic2-starter-tutorial
](https://github.com/driftyco/ionic2-starter-tutorial/pull/26)