### PR TITLE
minor typo in Radio Alerts description

### DIFF
--- a/_includes/v2_fluid/component-docs/alert.html
+++ b/_includes/v2_fluid/component-docs/alert.html
@@ -138,7 +138,7 @@ export class MyPage {
   Demo Source
 </a>
 
-Radio Alerts are a type of Confirmation Alert, but use the [Radio](http://ionicframework.com/docs/v2/components/#radio) component to offer several choices. They offer A set of options is provided to the user, but only one option can be chosen.
+Radio Alerts are a type of Confirmation Alert, but use the [Radio](http://ionicframework.com/docs/v2/components/#radio) component to offer several choices. A set of options is provided to the user, but only one option can be chosen.
 
 ```
 import { AlertController } from 'ionic-angular';


### PR DESCRIPTION
There's an extra "They offer" in the Radio Alerts description. This commit removes it, or it's possible that there's a missing sentence here.