### PR TITLE
Fix links "Demo Source" breaking

### DIFF
--- a/_includes/v2_fluid/component-docs/action-sheets.html
+++ b/_includes/v2_fluid/component-docs/action-sheets.html
@@ -12,7 +12,7 @@ The Action Sheet always appears above any other components on the page, and must
 _For more information, Check out the [API docs](../api/components/action-sheet/ActionSheetController)._
 
 <h3 class="section-nav">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/action-sheets/basic">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/action-sheets/basic">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/alert.html
+++ b/_includes/v2_fluid/component-docs/alert.html
@@ -23,7 +23,7 @@ _For more information, Check out the [API docs](../api/components/alert/AlertCon
 
 <h3 class="section-nav" id="alerts">Basic Usage:</h3>
 
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/alerts/basic">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/alerts/basic">
   Demo Source
 </a>
 
@@ -49,7 +49,7 @@ export class MyPage {
 
 <h3 class="section-nav" id="alert-prompt">Prompt Alerts</h3>
 
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/alerts/prompt">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/alerts/prompt">
   Demo Source
 </a>
 
@@ -94,7 +94,7 @@ export class MyPage {
 
 <h3 class="section-nav" id="alert-confirm">Confirmation Alerts</h3>
 
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/alerts/confirm">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/alerts/confirm">
   Demo Source
 </a>
 
@@ -134,7 +134,7 @@ export class MyPage {
 
 <h3 class="section-nav" id="alert-radio">Radio</h3>
 
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/alerts/radio">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/alerts/radio">
   Demo Source
 </a>
 
@@ -174,7 +174,7 @@ export class MyPage {
 
 <h3 class="section-nav" id="alert-checkbox">Checkbox</h3>
 
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/alerts/checkbox">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/alerts/checkbox">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/badges.html
+++ b/_includes/v2_fluid/component-docs/badges.html
@@ -10,7 +10,7 @@ _For more information, Check out the [API docs](../api/components/badge/Badge)._
 
 <h3 class="section-nav">Basic Usage</h3>
 
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/badges">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/badges">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/buttons.html
+++ b/_includes/v2_fluid/component-docs/buttons.html
@@ -32,7 +32,7 @@ _For more information, Check out the [API docs](../api/components/button/Button)
 </ul>
 
 <h3 class="no-para">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/buttons/basic">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/buttons/basic">
   Demo Source
 </a>
 
@@ -51,7 +51,7 @@ The `primary` property sets the color of the button. Ionic includes a number of 
 ```
 
 <h3 class="section-nav" id="outline-buttons">Outline Style</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/buttons/outline">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/buttons/outline">
   Demo Source
 </a>
 
@@ -66,7 +66,7 @@ To use the outline style for a button, just add the `outline` property:
 ```
 
 <h3 class="section-nav" id="clear-buttons">Clear Style</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/buttons/clear">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/buttons/clear">
   Demo Source
 </a>
 
@@ -81,7 +81,7 @@ To use the clear style for a button, just add the `clear` property:
 ```
 
 <h3 class="section-nav" id="round-buttons">Round Buttons</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/buttons/round">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/buttons/round">
   Demo Source
 </a>
 
@@ -96,7 +96,7 @@ To create a button with rounded corners, just add the `round` property:
 ```
 
 <h3 class="section-nav" id="block-buttons">Block Buttons</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/buttons/block">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/buttons/block">
   Demo Source
 </a>
 
@@ -107,7 +107,7 @@ Adding `block` to a button will make the button take 100% of its parent's width.
 ```
 
 <h3 class="section-nav" id="full-buttons">Full Buttons</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/buttons/full">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/buttons/full">
   Demo Source
 </a>
 
@@ -118,7 +118,7 @@ Adding `full` to a button will also make the button take 100% of its parent's wi
 ```
 
 <h3 class="section-nav" id="button-sizes">Button Sizes</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/buttons/sizes">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/buttons/sizes">
   Demo Source
 </a>
 
@@ -131,7 +131,7 @@ Add the `large` attribute to make a button larger, or `small` to make it smaller
 ```
 
 <h3 class="section-nav" id="icon-buttons">Icon Buttons</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/buttons/icons">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/buttons/icons">
   Demo Source
 </a>
 
@@ -158,7 +158,7 @@ To add icons to a button, add an icon component inside of it:
 ```
 
 <h3 class="section-nav" id="floating-action-buttons">Floating Action Buttons</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/buttons/fab">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/buttons/fab">
   Demo Source
 </a>
 
@@ -169,7 +169,7 @@ Adding `fab` to a button will turn it into a floating action button. This is a m
 ```
 
 <h3 class="section-nav" id="buttons-in-components">Buttons In Components</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/buttons/components">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/buttons/components">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/cards.html
+++ b/_includes/v2_fluid/component-docs/cards.html
@@ -23,7 +23,7 @@
 </ul>
 
 <h3 class="no-para">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/cards/basic">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/cards/basic">
   Demo Source
 </a>
 
@@ -60,7 +60,7 @@ Just like a normal page, cards can be customized to include headers. To add a he
 
 
 <h3 class="section-nav" id="card-list">Lists In Cards</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/cards/list">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/cards/list">
   Demo Source
 </a>
 
@@ -109,7 +109,7 @@ A card can contain a list of items. Add an `ion-list` component inside of the `i
 
 
 <h3 class="section-nav" id="card-image">Images In Cards</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/cards/image">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/cards/image">
   Demo Source
 </a>
 
@@ -131,7 +131,7 @@ Images often vary in size, so it is important that they adopt a consistent style
 ```
 
 <h3 class="section-nav" id="card-background">Background Images</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/cards/background">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/cards/background">
   Demo Source
 </a>
 
@@ -212,7 +212,7 @@ The styles from different types of cards can be combined to create advanced card
 </ul>
 
 <h3 class="section-nav" id="card-advanced-social">Social Cards</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/cards/advanced-social">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/cards/advanced-social">
   Demo Source
 </a>
 
@@ -259,7 +259,7 @@ It's often necessary to create social cards within an application. Using a combi
 ```
 
 <h3 class="section-nav" id="card-advanced-map">Map Cards</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/cards/advanced-map">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/cards/advanced-map">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/checkbox.html
+++ b/_includes/v2_fluid/component-docs/checkbox.html
@@ -9,7 +9,7 @@ A checkbox is an input component that holds a *boolean* value. Checkboxes are no
 _For more information, Check out the [API docs](../api/components/checkbox/Checkbox)._
 
 <h3 class="no-para">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/checkboxes">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/checkboxes">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/datetime.html
+++ b/_includes/v2_fluid/component-docs/datetime.html
@@ -9,7 +9,7 @@ The DateTime component is used to present an interface which makes it easy for u
 _For more information, Check out the [API docs](../api/components/datetime/DateTime)._
 
 <h3 class="no-para">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/datetime">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/datetime">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/gestures.html
+++ b/_includes/v2_fluid/component-docs/gestures.html
@@ -7,7 +7,7 @@
 Basic gestures can be accessed from HTML by binding to `tap`, `press`, `pan`, `swipe`, `rotate`, and `pinch` events.
 
 <h3 class="no-para">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/gestures">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/gestures">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/grid.html
+++ b/_includes/v2_fluid/component-docs/grid.html
@@ -10,7 +10,7 @@ Rows have no padding or margin applied to them. If that is needed, `ion-grid` ca
 
 In order to set width use `width` attribute on ion-col tag.
 
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/grid">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/grid">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/icons.html
+++ b/_includes/v2_fluid/component-docs/icons.html
@@ -9,7 +9,7 @@ Ionic comes with the same 700+ [Ionicons](/docs/v2/ionicons/) icons we've all co
 _For more information, Check out the [API docs](../api/components/icon/Icon)._
 
 ### Basic Usage
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/icons">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/icons">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/inputs.html
+++ b/_includes/v2_fluid/component-docs/inputs.html
@@ -23,7 +23,7 @@ _For more information, Check out the [API docs](../api/components/input/Input)._
 </ul>
 
 <h3 class="section-nav" id="fixed-inline-labels">Fixed Labels</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/inputs/fixed-inline">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/inputs/fixed-inline">
   Demo Source
 </a>
 
@@ -47,7 +47,7 @@ Use `fixed` to place a label to the left of the input element. The label does no
 
 
 <h3 class="section-nav" id="floating-labels">Floating Labels</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/inputs/floating">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/inputs/floating">
   Demo Source
 </a>
 
@@ -73,7 +73,7 @@ Enter text in the example to the right to see the floating labels in action.
 ```
 
 <h3 class="section-nav" id="inline-labels" class="section-header">Inline Labels</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/inputs/inline">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/inputs/inline">
   Demo Source
 </a>
 
@@ -99,7 +99,7 @@ An `ion-label` without any attributes is an inline label. The label does not hid
 </div>
 ```
 <h3 class="section-nav" id="inset-labels" class="section-header">Inset Labels</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/inputs/inset">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/inputs/inset">
   Demo Source
 </a>
 
@@ -122,7 +122,7 @@ By default each input item will fill 100% of the width of its parent element. Ma
 ```
 
 <h3 class="section-nav" id="placeholder-labels" class="section-header">Placeholder Labels</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/inputs/placeholder">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/inputs/placeholder">
   Demo Source
 </a>
 
@@ -144,7 +144,7 @@ Add the `placeholder` attribute to an `<input>` element to simulate the input's 
 ```
 
 <h3 class="section-nav" id="stacked-labels" class="section-header">Stacked Labels</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/inputs/stacked">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/inputs/stacked">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/lists.html
+++ b/_includes/v2_fluid/component-docs/lists.html
@@ -22,7 +22,7 @@ _For more information, Check out the [List API docs](../api/components/list/List
 </ul>
 
 <h3 class="section-nav" id="list-lines">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/lists/basic">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/lists/basic">
   Demo Source
 </a>
 
@@ -38,7 +38,7 @@ By default, all lists will be styled with divider lines:
 
 
 <h3 class="no-para" id="list-no-lines">No Lines</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/lists/no-lines">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/lists/no-lines">
   Demo Source
 </a>
 
@@ -53,7 +53,7 @@ Adding the `no-lines` attribute will hide the dividers between list items:
 ```
 
 <h3 class="section-nav" id="inset-list">Inset List</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/lists/inset">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/lists/inset">
   Demo Source
 </a>
 
@@ -68,7 +68,7 @@ Lists don’t have an outside margin by default.  To add one, add the `inset` at
 ```
 
 <h3 class="section-nav" id="list-dividers">List Dividers</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/lists/dividers">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/lists/dividers">
   Demo Source
 </a>
 
@@ -88,7 +88,7 @@ To divide groups of items, use `<ion-item-group>` instead of `<ion-list>`. Use `
 
 
 <h3 class="section-nav" id="list-headers">List Headers</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/lists/headers">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/lists/headers">
   Demo Source
 </a>
 
@@ -106,7 +106,7 @@ Each list can include a header at the top of the list:
 ```
 
 <h3 class="section-nav" id="icon-list">Icon List</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/lists/icon">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/lists/icon">
   Demo Source
 </a>
 
@@ -124,7 +124,7 @@ Adding [icons](#icons) to list items is a great way to hint about the contents o
 
 
 <h3 class="section-nav" id="avatar-list">Avatar List</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/lists/avatar">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/lists/avatar">
   Demo Source
 </a>
 
@@ -143,7 +143,7 @@ Item avatars showcase an image larger than an icon, but smaller than a thumbnail
 ```
 
 <h3 class="section-nav" id="multiline-list">Multi-line List</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/lists/multiline">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/lists/multiline">
   Demo Source
 </a>
 
@@ -163,7 +163,7 @@ Multi-line lists are identical to regular lists, except items have multiple line
 ```
 
 <h3 class="section-nav" id="sliding-list">Sliding List</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/lists/sliding">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/lists/sliding">
   Demo Source
 </a>
 
@@ -202,7 +202,7 @@ For more information, Check out the [API docs](../api/components/item/ItemSlidin
 
 
 <h3 class="section-nav" id="thumbnail-list">Thumbnail List</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/lists/thumbnail">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/lists/thumbnail">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/loading.html
+++ b/_includes/v2_fluid/component-docs/loading.html
@@ -10,7 +10,7 @@ By default, it shows a spinner based on the mode. Dynamic content can be passed 
 _For more information, Check out the [API docs](../api/components/loading/Loading)._
 
 <h3 class="section-nav">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/loading/basic">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/loading/basic">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/menus.html
+++ b/_includes/v2_fluid/component-docs/menus.html
@@ -11,7 +11,7 @@ Menu adapts to the appropriate style based on the platform.
 _For more information, Check out the [API docs](../api/components/menu/Menu)._
 
 <h3 class="section-nav">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/menus/basic">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/menus/basic">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/modals.html
+++ b/_includes/v2_fluid/component-docs/modals.html
@@ -9,7 +9,7 @@ Modals slide in off screen to display a temporary UI, often used for login or si
 _For more information, Check out the [API docs](../api/components/modal/ModalController)._
 
 <h3 class="section-nav">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/modals/basic">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/modals/basic">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/navigation.html
+++ b/_includes/v2_fluid/component-docs/navigation.html
@@ -15,7 +15,7 @@ Like native apps, URLs are not required for navigation in Ionic.  Instead, pages
 There are several ways to navigate throughout an Ionic app:
 
 <h3 id="basic_navigation">Basic Navigation</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/navigation/basic">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/navigation/basic">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/popover.html
+++ b/_includes/v2_fluid/component-docs/popover.html
@@ -12,7 +12,7 @@ The Popover is a view that floats above an app’s content. Popovers provide an 
 _For more information, Check out the [API docs](../api/components/popover/PopoverController)._
 
 <h3 class="no-para">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/popovers">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/popovers">
     Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/radio.html
+++ b/_includes/v2_fluid/component-docs/radio.html
@@ -9,7 +9,7 @@ Like the [checkbox](#checkbox), a radio is an input component that holds a *bool
 _For more information, Check out the [Radio Button API docs](../api/components/radio/RadioButton) and the [Radio Group API docs](../api/components/radio/RadioGroup)._
 
 <h3 class="section-nav">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/radios/basic">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/radios/basic">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/range.html
+++ b/_includes/v2_fluid/component-docs/range.html
@@ -9,7 +9,7 @@ A Range is a control that lets users select from a range of values by moving a s
 _For more information, Check out the [API docs](../api/components/range/Range)._
 
 <h3 class="section-nav">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/ranges">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/ranges">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/searchbar.html
+++ b/_includes/v2_fluid/component-docs/searchbar.html
@@ -9,7 +9,7 @@ A Searchbar binds to a model, and emits an input event when the model is changed
 _For more information, Check out the [API docs](../api/components/searchbar/Searchbar)._
 
 <h3 class="section-nav">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/searchbars">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/searchbars">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/segment.html
+++ b/_includes/v2_fluid/component-docs/segment.html
@@ -9,7 +9,7 @@ Segment is a collection of buttons that are displayed in line. They can act as a
 _For more information, Check out the [API docs](../api/components/segment/Segment)._
 
 <h3 class="section-nav">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/segments/basic">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/segments/basic">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/select.html
+++ b/_includes/v2_fluid/component-docs/select.html
@@ -6,7 +6,7 @@
 
 
 <h3 class="section-nav">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/selects/basic">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/selects/basic">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/slides.html
+++ b/_includes/v2_fluid/component-docs/slides.html
@@ -9,7 +9,7 @@ Slides make it easy to create galleries, tutorials, and page-based layouts. Slid
 _For more information, Check out the [Slides API docs](../api/components/slides/Slides) and the [Slide API docs](../api/components/slides/Slide)._
 
 <h3 class="section-nav">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/slides">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/slides">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/tabs.html
+++ b/_includes/v2_fluid/component-docs/tabs.html
@@ -18,7 +18,7 @@ _For more information, Check out the [Tabs API docs](../api/components/tabs/Tabs
 </ul>
 
 ### Basic Usage
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/tabs/basic">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/tabs/basic">
   Demo Source
 </a>
 
@@ -104,7 +104,7 @@ class Tab2 {
 ```
 
 <h3 class="section-nav" id="tabs-icon">Icon Tabs</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/tabs/icon">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/tabs/icon">
   Demo Source
 </a>
 
@@ -144,7 +144,7 @@ export class TabsIconPage {
 ```
 
 <h3 class="section-nav" id="tabs-icon-text">Icon and Text</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/tabs/icon-text">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/tabs/icon-text">
   Demo Source
 </a>
 
@@ -184,7 +184,7 @@ export class TabsTextPage {
 ```
 
 <h3 class="section-nav" id="tabs-badges">Badges</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/tabs/icon-text">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/tabs/icon-text">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/toast.html
+++ b/_includes/v2_fluid/component-docs/toast.html
@@ -9,7 +9,7 @@ Toast is a subtle notification that appears on top of an app's content. Typicall
 _For more information, Check out the [API docs](../api/components/toast/ToastController)._
 
 <h3 class="section-nav">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/toast/basic">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/toast/basic">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/toggle.html
+++ b/_includes/v2_fluid/component-docs/toggle.html
@@ -8,7 +8,7 @@ A toggle is an input component that holds a *boolean* value. Like the [checkbox]
 _For more information, Check out the [API docs](../api/components/toggle/Toggle)._
 
 <h3 class="no-para">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/toggles/basic">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/toggles/basic">
   Demo Source
 </a>
 

--- a/_includes/v2_fluid/component-docs/toolbar.html
+++ b/_includes/v2_fluid/component-docs/toolbar.html
@@ -20,7 +20,7 @@
 
 
 <h3 class="no-para">Basic Usage</h3>
-<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/app/pages/toolbar/basic">
+<a target="_blank" class="component-doc-demo" href="https://github.com/driftyco/ionic-preview-app/tree/master/src/pages/toolbar/basic">
   Demo Source
 </a>
 


### PR DESCRIPTION
After refactoring to beta.12 done in [ionic-preview-app](https://github.com/driftyco/ionic-preview-app/commit/b0efba173dbe95c8c9ae5569ab6e8d352ca75853) folder **app/** renamed to **src/** with this links "Demo source" breaking