### PR TITLE
Typo error in Setting up root component

### DIFF
--- a/docs/v2/getting-started/tutorial/project-structure/index.md
+++ b/docs/v2/getting-started/tutorial/project-structure/index.md
@@ -62,7 +62,7 @@ export class AppModule {}
 
 Every app has a *root module* that essentially controls the rest of the application. This is very similar to `ng-app` from Ionic and Angular 1. This is also where we bootstrap our app using `ionicBootstrap`.
 
-In this module, we're setting the room component to MyApp, in `src/app/app.component.ts`. This is the first component that gets loaded in our app, and it typically is a empty shell for other components to loaded into. In `app.component.ts`, we're setting out template to `src/app/app.html`, so lets look in there.
+In this module, we're setting the root component to MyApp, in `src/app/app.component.ts`. This is the first component that gets loaded in our app, and it typically is a empty shell for other components to loaded into. In `app.component.ts`, we're setting out template to `src/app/app.html`, so lets look in there.
 
 <h3 class="file-title">./src/app/app.html</h3>
 


### PR DESCRIPTION
There is a small typo error in explanation of setting up root component. It is written as "room" instead of "root".