### PR TITLE
fix the outdated URL of NIN logo

### DIFF
--- a/docs/components/index.html
+++ b/docs/components/index.html
@@ -1618,7 +1618,7 @@ search_sections: true
       <div class="list card">
 
         <div class="item item-avatar">
-          <img src="http://tutupash.com/site/assets/nin_logo.jpeg">
+          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/dc/Nine_Inch_Nails_logo.svg/220px-Nine_Inch_Nails_logo.svg.png">
           <h2>Pretty Hate Machine</h2>
           <p>Nine Inch Nails</p>
         </div>


### PR DESCRIPTION
Replace the outdated URL of NIN logo with a valid one from Wikipedia(https://en.wikipedia.org/wiki/Nine_Inch_Nails).