### PR TITLE
Try to explain better [content] = 'content'

### DIFF
--- a/docs/v2/getting-started/tutorial/project-structure/index.md
+++ b/docs/v2/getting-started/tutorial/project-structure/index.md
@@ -70,7 +70,9 @@ In this module, we're setting the root component to MyApp, in `src/app/app.compo
 Here's the main template for the app in `src/app/app.html`:
 
 ```html
-<ion-menu [content]="content">
+<ion-nav id="nav" [root]="rootPage" #nav swipeBackEnabled="false"></ion-nav>
+
+<ion-menu [content]="nav">
 
   <ion-header>
     <ion-toolbar>
@@ -87,10 +89,8 @@ Here's the main template for the app in `src/app/app.html`:
   </ion-content>
 
 </ion-menu>
-
-<ion-nav id="nav" [root]="rootPage" #content swipeBackEnabled="false"></ion-nav>
 ```
 
-In this template, we set up an [`ion-menu`](/docs/v2/components/#menus) to function as a side menu, and then an [`ion-nav`](/docs/v2/api/components/nav/Nav/) component to act as the main content area. The [`ion-menu`](/docs/v2/components/#menus)'s `[content]` property is bound to the local variable `content` from our [`ion-nav`](/docs/v2/api/components/nav/Nav/), so it knows where it should animate around.
+In this template, we set up an [`ion-menu`](/docs/v2/components/#menus) to function as a side menu, and then an [`ion-nav`](/docs/v2/api/components/nav/Nav/) component to act as the main content area. The [`ion-menu`](/docs/v2/components/#menus)'s `[content]` property is bound to the local variable `nav` from our [`ion-nav`](/docs/v2/api/components/nav/Nav/), so it knows where it should animate around.
 
 Next let's see how to create more pages and perform basic navigation.


### PR DESCRIPTION
The other thay I was with a team trying to explain this part of the code, was not easy to understand for them.
Maybe if you know perfectly what this code is doing it is ease but if not...

Is possible that we don't understand correctly and this is the problem let me explain, here we understand that:

```
<ion-menu [content]="content">
</ion-menu>

<ion-nav id="nav" [root]="rootPage" #content swipeBackEnabled="false"></ion-nav>
```

Can be explained as we save in _content_ variable an ion-nav reference and we pass it to _ion-menu_ on the input _content_.
Maybe somethig """"""like""""" this:

```
let content = get('ion-nav');
let menu = get('ion-menu');
menu.content = content;
```
We think that is easier to have something like that:

```
<ion-nav id="nav" [root]="rootPage" #nav swipeBackEnabled="false"></ion-nav>
<ion-menu [content]="nav">
</ion-menu>
```

Can be explained as we save in _nav_ variable an ion-nav reference and we pass it to _ion-menu_ on the input _content_.
Maybe somethig """"""like""""" this:
```
let nav = get('ion-nav');
let menu = get('ion-menu');
menu.content = nav;
```

If I'm right, maybe seems stupid but was very difficult to understand to the team, but maybe I'm wrong :S

Thanks!