### PR TITLE
no need for explicit templateURL path

### DIFF
--- a/docs/v2/getting-started/tutorial/adding-pages/index.md
+++ b/docs/v2/getting-started/tutorial/adding-pages/index.md
@@ -123,7 +123,7 @@ import {ItemDetailsPage} from '../item-details/item-details';
 
 
 @Component({
-  templateUrl: 'build/pages/list/list.html'
+  templateUrl: 'list.html'
 })
 export class ListPage {
   selectedItem: any;

--- a/docs/v2/getting-started/tutorial/adding-pages/index.md
+++ b/docs/v2/getting-started/tutorial/adding-pages/index.md
@@ -69,7 +69,7 @@ Below, we see the `HelloIonicPage` class. This creates a Page - an Angular compo
 import {Component} from '@angular/core';
 
 @Component({
-  templateUrl: 'build/pages/hello-ionic/hello-ionic.html'
+  templateUrl: 'hello-ionic.html'
 })
 export class HelloIonicPage {}
 ```


### PR DESCRIPTION
Just a simple portability and clarity issue. Noticed with the latest update it will still reference the page with out going through all the folders.. which can be problematic when you move things around.