### PR TITLE
Fixing mistake in usage of CLI

### DIFF
--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -8,7 +8,7 @@ header_sub_title: The powerful command line utility
 ## Adding a platform target
 
 ```bash
-$ ionic platform ios android
+$ ionic platform add ios android
 ```
 
 ## Building your app


### PR DESCRIPTION
You add a platform by typing `ionic platform add <platform>` not  `ionic platform <platform>`