### PR TITLE
Replacing incorrect icon reference

### DIFF
--- a/content/_includes/v2_fluid/component-docs/toolbar.html
+++ b/content/_includes/v2_fluid/component-docs/toolbar.html
@@ -50,7 +50,7 @@ One of the best uses of the toolbar is as a header.
   <ion-toolbar color="primary">
     <ion-buttons start>
       <button ion-button icon-only>
-        <ion-icon name="content"></ion-icon>
+        <ion-icon name="more"></ion-icon>
       </button>
     </ion-buttons>
 


### PR DESCRIPTION
The icon named ‘content’ did not exist in the library