### PR TITLE
Add missing square brackets to drive order

### DIFF
--- a/content/docs/v2/storage/index.md
+++ b/content/docs/v2/storage/index.md
@@ -97,7 +97,7 @@ options to pass to localForage. See the localForage config docs for possible opt
   imports: [
     IonicStorageModule.forRoot({
       name: &#39;__mydb&#39;,
-         driverOrder: &#39;indexeddb&#39;, &#39;sqlite&#39;, &#39;websql&#39;
+         driverOrder: &#91;&#39;indexeddb&#39;, &#39;sqlite&#39;, &#39;websql&#39;&#93;
     })
   ],
   bootstrap: ...,

--- a/content/docs/v2/storage/index.md
+++ b/content/docs/v2/storage/index.md
@@ -97,7 +97,7 @@ options to pass to localForage. See the localForage config docs for possible opt
   imports: [
     IonicStorageModule.forRoot({
       name: &#39;__mydb&#39;,
-         driverOrder: &#91;&#39;indexeddb&#39;, &#39;sqlite&#39;, &#39;websql&#39;&#93;
+         driverOrder: [&#39;indexeddb&#39;, &#39;sqlite&#39;, &#39;websql&#39;]
     })
   ],
   bootstrap: ...,


### PR DESCRIPTION
Square brackets were missing from the drive order in the docs, this simply adds them. It's correct on the github page (https://github.com/driftyco/ionic-storage#configuring-storage-new-in-117), but not in the docs.