### PR TITLE
redirect deeplinks

### DIFF
--- a/server/redirects.json
+++ b/server/redirects.json
@@ -64,6 +64,7 @@
   "/docs/v2/native/navigationbar": "/docs/v2/native/navigation-bar",
   "/docs/v2/native/speechrecognition": "/docs/v2/native/speech-recognition",
   "/docs/v2/native/base64-to%20gallery": "/docs/v2/native/base64-to-gallery",
+  "/docs/v2/native/ionic-deeplinks": "/docs/v2/native/deeplinks",
   "/docs/v2/resources/resources/what-is": "/docs/v2/cli",
   "/docs/v2/resources/books-and-courses": "/docs/v2/resources/#/books",
   "/docs/v2/setup/concepts": "/docs/v2/intro/concepts",


### PR DESCRIPTION
This redirect is needed because of this commit: https://github.com/driftyco/ionic-native/commit/016f174b53993873bf961d106383c1b747ef0283