### PR TITLE
The more books link was pointing to more guides

### DIFF
--- a/content/docs/resources/index.html
+++ b/content/docs/resources/index.html
@@ -189,7 +189,7 @@ angular_controller: ResourcesCtrl
         <p>by Sani Yusuf</p>
       </li>
       <li ng-show="hash != 'books'">
-        <a href="#guides" ng-click="hash = 'books'">More Books...</a>
+        <a href="#books" ng-click="hash = 'books'">More Books...</a>
       <li ng-show="hash == 'books'">
         <a href="https://www.amazon.com/Ionic-Cookbook-Second-Hoc-Phan-ebook/dp/B01C4D9VWS?ie=UTF8&keywords=ionic%202&qid=1464183332&ref_=sr_1_3&sr=8-3"
            target="_blank">Ionic 2 Cookbook - Second Edition</a>


### PR DESCRIPTION
The link to show "More books..." was pointing to guides instead of books, so when I clicked it, it was showing the guides, just made the change so it sends people to the more books page instead.