### PR TITLE
Fix grid's documentation errata

### DIFF
--- a/content/_includes/fluid/component-docs/grid.html
+++ b/content/_includes/fluid/component-docs/grid.html
@@ -28,7 +28,7 @@ The grid system is made of a 12 columns, and each `ion-col` can be sized by sett
 ```
 
 
-An `ion-col` can be sized for different breakpoints by setting the `ion-<breakpoint>-<width>`.
+An `ion-col` can be sized for different breakpoints by setting the `col-<breakpoint>-<width>`.
 
 ``` html
 <ion-grid>


### PR DESCRIPTION
Errata in "An `ion-col` can be sized for different breakpoints by setting the `ion-<breakpoint>-<width>.`"

It has to be `col-` inestead of `ion-`, for example: `<ion-col col-12 col-sm-9 col-md-6 col-lg-4 col-xl-3></ion-col>`

