### PR TITLE
remove --v2 note, as it is v2 by default

### DIFF
--- a/content/docs/intro/tutorial/index.md
+++ b/content/docs/intro/tutorial/index.md
@@ -32,7 +32,6 @@ $ ionic start MyIonic2Project tutorial
 - `start` will tell the CLI create a new app.
 - `MyIonic2Project` will be the directory name and the app name from your project.
 - `tutorial` will be the starter template for your project.
-- `--v2` tells the CLI that you want a 2.0 project.
 
 Along with creating your project, this will also install [npm modules](../../resources/what-is/#npm) for the application, and get [Cordova](../../resources/what-is/#cordova) set up and ready to go.
 


### PR DESCRIPTION
The tutorial has a description of the `--v2` flag. However, it seems that the projects are already ionic2 by default. Also, the example isn't using the `--v2` flag like the description of `--v2` seems to indicate.