### PR TITLE
docs(windows): refactor platform guide

### DIFF
--- a/content/docs/resources/platform-setup/windows-setup.md
+++ b/content/docs/resources/platform-setup/windows-setup.md
@@ -23,7 +23,7 @@ Once installed, you should have access to both `node` and `npm` from your comman
 The iOS SDK does not run on Windows, so nothing to do here. Still want to build for iOS, though? Check out [Package](http://ionic.io/cloud#packaging), part of the Ionic Cloud.
 
 ### Java
-We'll need to download Java from [their website](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html). The install puts Java in your `C:\Program Files\Java` folder, so navigate there and pick the version of Java you've installed. Copy this location (including the version number) as you'll need it for later.
+We'll need to download Java from [their website](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html). The install puts Java in your `C:\Program Files\Java` folder.
 
 ### Android
 Download Android Studio and go through the installer and set up the IDE. It should print out a location for where the Android SDK gets installed; copy this down for future use.
@@ -39,20 +39,24 @@ Accept the license and let the packages install.
 
 ### Environment Variables
 Now that everything's installed, we'll need to set some environment variables for our command line.
-From the startmenu, search for "System Environment Variables". From here, we'll update the user variable `PATH` and create a new variable of `JAVA_HOME`
+From the startmenu, search for "System Environment Variables". From here, we'll update the user variable `PATH` and create a new variable of `ANDROID_HOME`
 
-- `JAVA_HOME` : The path to where Java is installed.
-
+- `ANDROID_HOME` : The path to where the Android SDK is installed.
 - `PATH` : Two entries, one where Tools are installed for the Android SDK, and another for Platform tools
 
+Or set them with the Windows Command Line
+```bash
+set ANDROID_HOME=C:\<installation location>\sdk
+set PATH=%PATH%;%ANDROID_HOME%\tools;%ANDROID_HOME%\platform-tools
+```
 
 From here, we should be able to run
 
 ```bash
-# check java version
+# check Java version
 java -version
 
-# start android SDK manager
+# start the Android SDK manager
 android
 ```
 

--- a/content/docs/resources/platform-setup/windows-setup.md
+++ b/content/docs/resources/platform-setup/windows-setup.md
@@ -71,7 +71,7 @@ To build apps for Windows Universal, download and install Visual Studio 2015 Com
 With everything installed, you'll be able to add a windows platform from the command line with this command:
 
 ```bash
-ionic platform add windows
+ionic cordova platform add windows
 ```
 
 By default the `build` command produces two packages: Windows 8.1 and Windows Phone 8.1, which Ionic does not support. To upgrade Windows package to version 10 the following configuration setting must be added to configuration file (config.xml).

--- a/content/docs/resources/platform-setup/windows-setup.md
+++ b/content/docs/resources/platform-setup/windows-setup.md
@@ -22,11 +22,13 @@ Once installed, you should have access to both `node` and `npm` from your comman
 ### iOS
 The iOS SDK does not run on Windows, so nothing to do here. Still want to build for iOS, though? Check out [Package](http://ionic.io/cloud#packaging), part of the Ionic Cloud.
 
-### Java
-We'll need to download Java from [their website](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html). The install puts Java in your `C:\Program Files\Java` folder.
+### Java JDK
+We'll need to download and install the Java JDK from [their website](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
 
-### Android
-Download Android Studio and go through the installer and set up the IDE. It should print out a location for where the Android SDK gets installed; copy this down for future use.
+### Android SDK
+Download Android Studio and go through the installer and set up the IDE. It should print out a location for where the Android SDK gets installed. Copy this down for future use.
+
+If you don't want to download Android Studio you can just download the Android SDK files for Windows [here](https://developer.android.com/studio/index.html#downloads)
 
 Next, inside the new `SDK` location, we'll run `tools/android` to open the Android SDK Manager. We'll want to install:
 


### PR DESCRIPTION
- The JDK Installer sets the JAVA_HOME Path automatically on Windows.
- I added the CMD command for the ANDROID_HOME path variables
- Explained how to download the Android SDK without Android Studio